### PR TITLE
Update to helm v3 and chart api v2

### DIFF
--- a/haproxy-ingress/.helmignore
+++ b/haproxy-ingress/.helmignore
@@ -14,8 +14,10 @@
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project
 .idea/
 *.tmproj
+.vscode/

--- a/haproxy-ingress/Chart.yaml
+++ b/haproxy-ingress/Chart.yaml
@@ -1,18 +1,19 @@
-apiVersion: v1
+apiVersion: v2
 name: haproxy-ingress
+description: Ingress controller for HAProxy loadbalancer
+type: application
 version: 0.0.27
 appVersion: 0.7.2
-home: https://github.com/jcmoraisjr/haproxy-ingress
-description: Ingress controller implementation for haproxy loadbalancer.
 icon: https://haproxy-ingress.github.io/favicons/favicon-256.png
 keywords:
-  - ingress
   - haproxy
+  - ingress
+home: https://haproxy-ingress.github.io
 sources:
   - https://github.com/jcmoraisjr/haproxy-ingress
+  - https://github.com/haproxy-ingress/charts
 maintainers:
   - name: jcmoraisjr
     email: jcmoraisjr@gmail.com
   - name: xianlubird
     email: xianlubird@gmail.com
-engine: gotpl

--- a/haproxy-ingress/Chart.yaml
+++ b/haproxy-ingress/Chart.yaml
@@ -15,5 +15,3 @@ sources:
 maintainers:
   - name: jcmoraisjr
     email: jcmoraisjr@gmail.com
-  - name: xianlubird
-    email: xianlubird@gmail.com

--- a/haproxy-ingress/templates/NOTES.txt
+++ b/haproxy-ingress/templates/NOTES.txt
@@ -6,12 +6,12 @@ Get the application URL by running these commands:
 {{- if (not (empty .Values.controller.service.nodePorts)) }}
   export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
 {{- else }}
-  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "haproxy-ingress.controller.fullname" . }})
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ include "haproxy-ingress.controller.fullname" . }})
 {{- end }}
 {{- if (not (empty .Values.controller.service.nodePorts)) }}
   export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
 {{- else }}
-  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxy-ingress.controller.fullname" . }})
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ include "haproxy-ingress.controller.fullname" . }})
 {{- end }}
   export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
 
@@ -19,10 +19,10 @@ Get the application URL by running these commands:
   echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."
 {{- else if contains "LoadBalancer" .Values.controller.service.type }}
 It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "haproxy-ingress.fullname" . }}'
+You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ include "haproxy-ingress.fullname" . }}'
 {{- else if contains "ClusterIP"  .Values.controller.service.type }}
 Get the application URL by running these commands:
-  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "haproxy-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ include "haproxy-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
   echo "Visit http://127.0.0.1:8080 to access your application."
 {{- end }}

--- a/haproxy-ingress/templates/NOTES.txt
+++ b/haproxy-ingress/templates/NOTES.txt
@@ -1,39 +1,45 @@
-The haproxy-ingress controller has been installed.
+HAProxy Ingress has been installed!
 
 {{- if contains "NodePort" .Values.controller.service.type }}
+
+HAProxy is exposed as a `NodePort` type service.
 Get the application URL by running these commands:
 
-{{- if (not (empty .Values.controller.service.nodePorts)) }}
-  export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
-{{- else }}
-  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ include "haproxy-ingress.controller.fullname" . }})
-{{- end }}
-{{- if (not (empty .Values.controller.service.nodePorts)) }}
-  export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
-{{- else }}
-  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ include "haproxy-ingress.controller.fullname" . }})
-{{- end }}
-  export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
+    export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ include "haproxy-ingress.fullname" . }})
+    export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ include "haproxy-ingress.fullname" . }})
+    export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
 
-  echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
-  echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."
+    echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
+    echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."
+
 {{- else if contains "LoadBalancer" .Values.controller.service.type }}
+
+HAProxy is exposed as a `LoadBalancer` type service.
 It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ include "haproxy-ingress.fullname" . }}'
-{{- else if contains "ClusterIP"  .Values.controller.service.type }}
+You can watch the status by running:
+
+    kubectl --namespace {{ .Release.Namespace }} get services {{ include "haproxy-ingress.fullname" . }} -o wide -w
+
+{{- else if contains "ClusterIP" .Values.controller.service.type }}
+
+HAProxy is exposed as a `ClusterIP` type service.
 Get the application URL by running these commands:
-  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ include "haproxy-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
-  echo "Visit http://127.0.0.1:8080 to access your application."
+
+    export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ include "haproxy-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+    kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+    echo "Visit http://127.0.0.1:8080 to access your application."
+
 {{- end }}
 
 An example Ingress that makes use of the controller:
 
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1beta1
   kind: Ingress
   metadata:
+    annotations:
+      kubernetes.io/ingress.class: haproxy
     name: example
-    namespace: foo
+    namespace: default
   spec:
     rules:
       - host: www.example.com
@@ -41,5 +47,5 @@ An example Ingress that makes use of the controller:
           paths:
             - backend:
                 serviceName: exampleService
-                servicePort: 80
+                servicePort: 8080
               path: /

--- a/haproxy-ingress/templates/_helpers.tpl
+++ b/haproxy-ingress/templates/_helpers.tpl
@@ -1,84 +1,93 @@
-{{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
+{{/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *
+  *  Name (defaults to "haproxy-ingress") and a fully qualified name
+  *  (defaults to "<release>-haproxy-ingress") of controller and a variant with `.Values.defaultBackend.name`
+  *  for the default backend.
+  *
+  *  We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+  *  If release name contains the chart name, it will be used as a full name.
+  *
+  */}}
 {{- define "haproxy-ingress.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
-{{/*
-Create the app label for controller
-*/}}
-{{- define "haproxy-ingress.labels.app.controller" -}}
-{{ default "haproxy-ingress-controller" }}
-{{- end -}}
-
-{{/*
-Create the app label for default backend
-*/}}
-{{- define "haproxy-ingress.labels.app.default-backend" -}}
-{{ default "haproxy-ingress-default-backend" }}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
 {{- define "haproxy-ingress.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.fullnameOverride }}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 
+{{- define "haproxy-ingress.defaultBackend.name" -}}
+  {{- printf "%s-%s" .Chart.Name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "haproxy-ingress.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified controller name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "haproxy-ingress.controller.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified default backend name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
 {{- define "haproxy-ingress.defaultBackend.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+  {{- $name := default .Chart.Name .Values.nameOverride }}
+  {{- if contains $name .Release.Name }}
+    {{- printf "%s-%s" .Release.Name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the service account to use
-*/}}
+
+{{/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *
+  *  Common and selector labels
+  *
+  *  We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+  *
+  */}}
+{{- define "haproxy-ingress.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "haproxy-ingress.labels" -}}
+helm.sh/chart: {{ include "haproxy-ingress.chart" . }}
+{{ include "haproxy-ingress.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "haproxy-ingress.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "haproxy-ingress.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "haproxy-ingress.defaultBackend.labels" -}}
+helm.sh/chart: {{ include "haproxy-ingress.chart" . }}
+{{ include "haproxy-ingress.defaultBackend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "haproxy-ingress.defaultBackend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "haproxy-ingress.defaultBackend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *
+  *  Create the name of the service account to use
+  *
+  */}}
 {{- define "haproxy-ingress.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "haproxy-ingress.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.serviceAccount.create }}
+    {{- default (include "haproxy-ingress.fullname" .) .Values.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.serviceAccount.name }}
+  {{- end }}
+{{- end }}

--- a/haproxy-ingress/templates/clusterrole.yaml
+++ b/haproxy-ingress/templates/clusterrole.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.fullname" . }}
 rules:
   - apiGroups:

--- a/haproxy-ingress/templates/clusterrole.yaml
+++ b/haproxy-ingress/templates/clusterrole.yaml
@@ -3,11 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.fullname" . }}
+  name: {{ include "haproxy-ingress.fullname" . }}
 rules:
   - apiGroups:
       - ""

--- a/haproxy-ingress/templates/clusterrole.yaml
+++ b/haproxy-ingress/templates/clusterrole.yaml
@@ -55,4 +55,4 @@ rules:
       - ingresses/status
     verbs:
       - update
-{{- end -}}
+{{- end }}

--- a/haproxy-ingress/templates/clusterrolebinding.yaml
+++ b/haproxy-ingress/templates/clusterrolebinding.yaml
@@ -3,20 +3,20 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.fullname" . }}
+  name: {{ include "haproxy-ingress.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "haproxy-ingress.fullname" . }}
+  name: {{ include "haproxy-ingress.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "haproxy-ingress.serviceAccountName" . }}
+    name: {{ include "haproxy-ingress.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
   - apiGroup: rbac.authorization.k8s.io
     kind: User
-    name: {{ template "haproxy-ingress.fullname" . }}
+    name: {{ include "haproxy-ingress.fullname" . }}
 {{- end -}}

--- a/haproxy-ingress/templates/clusterrolebinding.yaml
+++ b/haproxy-ingress/templates/clusterrolebinding.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/haproxy-ingress/templates/clusterrolebinding.yaml
+++ b/haproxy-ingress/templates/clusterrolebinding.yaml
@@ -19,4 +19,4 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: {{ include "haproxy-ingress.fullname" . }}
-{{- end -}}
+{{- end }}

--- a/haproxy-ingress/templates/controller-configmap.yaml
+++ b/haproxy-ingress/templates/controller-configmap.yaml
@@ -2,12 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
   healthz-port: {{ .Values.controller.healthzPort | quote }}

--- a/haproxy-ingress/templates/controller-configmap.yaml
+++ b/haproxy-ingress/templates/controller-configmap.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}
+  name: {{ include "haproxy-ingress.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
   healthz-port: {{ .Values.controller.healthzPort | quote }}

--- a/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/haproxy-ingress/templates/controller-daemonset.yaml
@@ -3,12 +3,12 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.labels.app.controller" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}
+  name: {{ include "haproxy-ingress.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   updateStrategy:
@@ -16,7 +16,7 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   selector:
     matchLabels:
-      app: {{ template "haproxy-ingress.labels.app.controller" . }}
+      app: {{ include "haproxy-ingress.labels.app.controller" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
@@ -28,7 +28,7 @@ spec:
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
       {{- end }}
       labels:
-        app: {{ template "haproxy-ingress.labels.app.controller" . }}
+        app: {{ include "haproxy-ingress.labels.app.controller" . }}
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
         {{- if .Values.controller.podLabels }}
@@ -39,7 +39,7 @@ spec:
       affinity:
 {{ toYaml .Values.controller.podAffinity | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ template "haproxy-ingress.serviceAccountName" . }}
+      serviceAccountName: {{ include "haproxy-ingress.serviceAccountName" . }}
     {{- if .Values.controller.initContainers }}
       initContainers:
 {{ toYaml .Values.controller.initContainers | indent 8 }}
@@ -49,13 +49,13 @@ spec:
           image:  "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
           args:
-            - --configmap={{ .Release.Namespace }}/{{ template "haproxy-ingress.controller.fullname" . }}
+            - --configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.controller.fullname" . }}
             - --ingress-class={{ .Values.controller.ingressClass }}
             - --sort-backends
           {{- if .Values.controller.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "haproxy-ingress.controller.fullname" . }}-tcp
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.controller.fullname" . }}-tcp
           {{- end }}
-            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "haproxy-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ include "haproxy-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
             {{- if $value }}
             - --{{ $key }}={{ $value }}
@@ -175,7 +175,7 @@ spec:
       volumes:
         - name: haproxy-template
           configMap:
-            name: {{ template "haproxy-ingress.controller.fullname" . }}-template
+            name: {{ include "haproxy-ingress.controller.fullname" . }}-template
 {{- end }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}

--- a/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/haproxy-ingress/templates/controller-daemonset.yaml
@@ -3,12 +3,8 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   updateStrategy:
@@ -16,8 +12,7 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   selector:
     matchLabels:
-      app: {{ include "haproxy-ingress.labels.app.controller" . }}
-      release: {{ .Release.Name }}
+      {{- include "haproxy-ingress.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -28,9 +23,7 @@ spec:
 {{ toYaml .Values.controller.podAnnotations | indent 8 }}
       {{- end }}
       labels:
-        app: {{ include "haproxy-ingress.labels.app.controller" . }}
-        component: "{{ .Values.controller.name }}"
-        release: {{ .Release.Name }}
+        {{- include "haproxy-ingress.selectorLabels" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
@@ -49,11 +42,11 @@ spec:
           image:  "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
           args:
-            - --configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.controller.fullname" . }}
+            - --configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.fullname" . }}
             - --ingress-class={{ .Values.controller.ingressClass }}
             - --sort-backends
           {{- if .Values.controller.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.controller.fullname" . }}-tcp
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.fullname" . }}-tcp
           {{- end }}
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ include "haproxy-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
@@ -175,7 +168,7 @@ spec:
       volumes:
         - name: haproxy-template
           configMap:
-            name: {{ include "haproxy-ingress.controller.fullname" . }}-template
+            name: {{ include "haproxy-ingress.fullname" . }}-template
 {{- end }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}

--- a/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/haproxy-ingress/templates/controller-daemonset.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.controller.kind "DaemonSet" -}}
+{{- if eq .Values.controller.kind "DaemonSet" -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -25,7 +25,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/controller-template.yaml") . | sha256sum }}
 {{- end }}
       {{- if .Values.controller.podAnnotations }}
-{{ toYaml .Values.controller.podAnnotations | indent 8}}
+{{ toYaml .Values.controller.podAnnotations | indent 8 }}
       {{- end }}
       labels:
         app: {{ include "haproxy-ingress.labels.app.controller" . }}

--- a/haproxy-ingress/templates/controller-deployment.yaml
+++ b/haproxy-ingress/templates/controller-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.controller.kind "Deployment" -}}
+{{- if eq .Values.controller.kind "Deployment" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +30,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/controller-template.yaml") . | sha256sum }}
 {{- end }}
       {{- if .Values.controller.podAnnotations }}
-{{ toYaml .Values.controller.podAnnotations | indent 8}}
+{{ toYaml .Values.controller.podAnnotations | indent 8 }}
       {{- end }}
       labels:
         app: {{ include "haproxy-ingress.labels.app.controller" . }}

--- a/haproxy-ingress/templates/controller-deployment.yaml
+++ b/haproxy-ingress/templates/controller-deployment.yaml
@@ -3,12 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if not .Values.controller.autoscaling.enabled }}
@@ -20,9 +16,7 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   selector:
     matchLabels:
-      app: {{ include "haproxy-ingress.labels.app.controller" . }}
-      component: "{{ .Values.controller.name }}"
-      release: {{ .Release.Name }}
+      {{- include "haproxy-ingress.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -33,9 +27,7 @@ spec:
 {{ toYaml .Values.controller.podAnnotations | indent 8 }}
       {{- end }}
       labels:
-        app: {{ include "haproxy-ingress.labels.app.controller" . }}
-        component: "{{ .Values.controller.name }}"
-        release: {{ .Release.Name }}
+        {{- include "haproxy-ingress.selectorLabels" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
@@ -54,11 +46,11 @@ spec:
           image:  "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
           args:
-            - --configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.controller.fullname" . }}
+            - --configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.fullname" . }}
             - --ingress-class={{ .Values.controller.ingressClass }}
             - --sort-backends
           {{- if .Values.controller.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.controller.fullname" . }}-tcp
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.fullname" . }}-tcp
           {{- end }}
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ include "haproxy-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
@@ -169,7 +161,7 @@ spec:
       volumes:
         - name: haproxy-template
           configMap:
-            name: {{ include "haproxy-ingress.controller.fullname" . }}-template
+            name: {{ include "haproxy-ingress.fullname" . }}-template
 {{- end }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}

--- a/haproxy-ingress/templates/controller-deployment.yaml
+++ b/haproxy-ingress/templates/controller-deployment.yaml
@@ -3,12 +3,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.labels.app.controller" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}
+  name: {{ include "haproxy-ingress.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if not .Values.controller.autoscaling.enabled }}
@@ -20,7 +20,7 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   selector:
     matchLabels:
-      app: {{ template "haproxy-ingress.labels.app.controller" . }}
+      app: {{ include "haproxy-ingress.labels.app.controller" . }}
       component: "{{ .Values.controller.name }}"
       release: {{ .Release.Name }}
   template:
@@ -33,7 +33,7 @@ spec:
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
       {{- end }}
       labels:
-        app: {{ template "haproxy-ingress.labels.app.controller" . }}
+        app: {{ include "haproxy-ingress.labels.app.controller" . }}
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
         {{- if .Values.controller.podLabels }}
@@ -44,7 +44,7 @@ spec:
       affinity:
 {{ toYaml .Values.controller.podAffinity | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ template "haproxy-ingress.serviceAccountName" . }}
+      serviceAccountName: {{ include "haproxy-ingress.serviceAccountName" . }}
     {{- if .Values.controller.initContainers }}
       initContainers:
 {{ toYaml .Values.controller.initContainers | indent 8 }}
@@ -54,13 +54,13 @@ spec:
           image:  "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
           args:
-            - --configmap={{ .Release.Namespace }}/{{ template "haproxy-ingress.controller.fullname" . }}
+            - --configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.controller.fullname" . }}
             - --ingress-class={{ .Values.controller.ingressClass }}
             - --sort-backends
           {{- if .Values.controller.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "haproxy-ingress.controller.fullname" . }}-tcp
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.controller.fullname" . }}-tcp
           {{- end }}
-            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "haproxy-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ include "haproxy-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
             {{- if $value }}
             - --{{ $key }}={{ $value }}
@@ -169,7 +169,7 @@ spec:
       volumes:
         - name: haproxy-template
           configMap:
-            name: {{ template "haproxy-ingress.controller.fullname" . }}-template
+            name: {{ include "haproxy-ingress.controller.fullname" . }}-template
 {{- end }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}

--- a/haproxy-ingress/templates/controller-hpa.yaml
+++ b/haproxy-ingress/templates/controller-hpa.yaml
@@ -3,18 +3,14 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1beta2
     kind: Deployment
-    name: {{ include "haproxy-ingress.controller.fullname" . }}
+    name: {{ include "haproxy-ingress.fullname" . }}
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:

--- a/haproxy-ingress/templates/controller-hpa.yaml
+++ b/haproxy-ingress/templates/controller-hpa.yaml
@@ -3,18 +3,18 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}
+  name: {{ include "haproxy-ingress.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1beta2
     kind: Deployment
-    name: {{ template "haproxy-ingress.controller.fullname" . }}
+    name: {{ include "haproxy-ingress.controller.fullname" . }}
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:

--- a/haproxy-ingress/templates/controller-hpa.yaml
+++ b/haproxy-ingress/templates/controller-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.controller.kind "Deployment") .Values.controller.autoscaling.enabled }}
+{{- if and (eq .Values.controller.kind "Deployment") .Values.controller.autoscaling.enabled -}}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/haproxy-ingress/templates/controller-metrics-service.yaml
+++ b/haproxy-ingress/templates/controller-metrics-service.yaml
@@ -7,12 +7,8 @@ metadata:
 {{ toYaml .Values.controller.metrics.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ include "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.controller.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}-metrics
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}-metrics
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.controller.metrics.service.clusterIP }}
@@ -34,8 +30,6 @@ spec:
       port: {{ .Values.controller.metrics.service.servicePort }}
       targetPort: metrics
   selector:
-    app: {{ include "haproxy-ingress.labels.app.controller" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
+    {{- include "haproxy-ingress.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.controller.metrics.service.type }}"
 {{- end }}

--- a/haproxy-ingress/templates/controller-metrics-service.yaml
+++ b/haproxy-ingress/templates/controller-metrics-service.yaml
@@ -7,12 +7,12 @@ metadata:
 {{ toYaml .Values.controller.metrics.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "haproxy-ingress.labels.app.controller" . }}
+    app: {{ include "haproxy-ingress.labels.app.controller" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}-metrics
+  name: {{ include "haproxy-ingress.controller.fullname" . }}-metrics
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.controller.metrics.service.clusterIP }}
@@ -34,7 +34,7 @@ spec:
       port: {{ .Values.controller.metrics.service.servicePort }}
       targetPort: metrics
   selector:
-    app: {{ template "haproxy-ingress.labels.app.controller" . }}
+    app: {{ include "haproxy-ingress.labels.app.controller" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.metrics.service.type }}"

--- a/haproxy-ingress/templates/controller-metrics-service.yaml
+++ b/haproxy-ingress/templates/controller-metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled }}
+{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
@@ -2,16 +2,10 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "haproxy-ingress.labels.app.controller" . }}
-      release: {{ .Release.Name }}
-      component: "{{ .Values.controller.name }}"
+      {{- include "haproxy-ingress.selectorLabels" . | nindent 6 }}
   minAvailable: {{ .Values.controller.minAvailable }}

--- a/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
@@ -2,16 +2,16 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.labels.app.controller" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}
+  name: {{ include "haproxy-ingress.controller.fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "haproxy-ingress.labels.app.controller" . }}
+      app: {{ include "haproxy-ingress.labels.app.controller" . }}
       release: {{ .Release.Name }}
       component: "{{ .Values.controller.name }}"
   minAvailable: {{ .Values.controller.minAvailable }}

--- a/haproxy-ingress/templates/controller-service.yaml
+++ b/haproxy-ingress/templates/controller-service.yaml
@@ -38,32 +38,32 @@ spec:
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
 {{- end }}
   ports:
-  {{- if .Values.controller.enableStaticPorts }}
+{{- if .Values.controller.enableStaticPorts }}
   {{- range .Values.controller.service.httpPorts }}
     - name: "http-{{ .port }}"
       port: {{ .port }}
       protocol: TCP
       targetPort: {{ .targetPort }}
-      {{- if (not (empty .nodePort)) }}
+    {{- if (not (empty .nodePort)) }}
       nodePort: {{ .nodePort }}
-      {{- end }}
+    {{- end }}
   {{- end }}
   {{- range .Values.controller.service.httpsPorts }}
     - name: "https-{{ .port }}"
       port: {{ .port }}
       protocol: TCP
       targetPort: {{ .targetPort }}
-      {{- if (not (empty .nodePort)) }}
+    {{- if (not (empty .nodePort)) }}
       nodePort: {{ .nodePort }}
-      {{- end }}
+    {{- end }}
   {{- end }}
-  {{- end }}
-  {{- range $key, $value := .Values.controller.tcp }}
+{{- end }}
+{{- range $key, $value := .Values.controller.tcp }}
     - name: "{{ tpl $key $ }}-tcp"
       port: {{ tpl $key $ }}
       protocol: TCP
       targetPort: "{{ tpl $key $ }}-tcp"
-  {{- end }}
+{{- end }}
   selector:
     app: {{ include "haproxy-ingress.labels.app.controller" . }}
     component: "{{ .Values.controller.name }}"

--- a/haproxy-ingress/templates/controller-service.yaml
+++ b/haproxy-ingress/templates/controller-service.yaml
@@ -6,15 +6,11 @@ metadata:
 {{ toYaml .Values.controller.service.annotations | indent 4 }}
 {{- end }}
   labels:
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
 {{- if .Values.controller.service.labels }}
 {{ toYaml .Values.controller.service.labels | indent 4 }}
 {{- end }}
-    app: {{ include "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}
+  name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.controller.service.clusterIP }}
@@ -65,7 +61,5 @@ spec:
       targetPort: "{{ tpl $key $ }}-tcp"
 {{- end }}
   selector:
-    app: {{ include "haproxy-ingress.labels.app.controller" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
+    {{- include "haproxy-ingress.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.controller.service.type }}"

--- a/haproxy-ingress/templates/controller-service.yaml
+++ b/haproxy-ingress/templates/controller-service.yaml
@@ -9,12 +9,12 @@ metadata:
 {{- if .Values.controller.service.labels }}
 {{ toYaml .Values.controller.service.labels | indent 4 }}
 {{- end }}
-    app: {{ template "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.labels.app.controller" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}
+  name: {{ include "haproxy-ingress.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.controller.service.clusterIP }}
@@ -65,7 +65,7 @@ spec:
       targetPort: "{{ tpl $key $ }}-tcp"
   {{- end }}
   selector:
-    app: {{ template "haproxy-ingress.labels.app.controller" . }}
+    app: {{ include "haproxy-ingress.labels.app.controller" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.service.type }}"

--- a/haproxy-ingress/templates/controller-stats-service.yaml
+++ b/haproxy-ingress/templates/controller-stats-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.stats.enabled }}
+{{- if .Values.controller.stats.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/haproxy-ingress/templates/controller-stats-service.yaml
+++ b/haproxy-ingress/templates/controller-stats-service.yaml
@@ -7,12 +7,8 @@ metadata:
 {{ toYaml .Values.controller.stats.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ include "haproxy-ingress.labels.app.controller" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.controller.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}-stats
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}-stats
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.controller.stats.service.clusterIP }}
@@ -34,8 +30,6 @@ spec:
       port: {{ .Values.controller.stats.service.servicePort }}
       targetPort: stats
   selector:
-    app: {{ include "haproxy-ingress.labels.app.controller" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
+    {{- include "haproxy-ingress.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.controller.stats.service.type }}"
 {{- end }}

--- a/haproxy-ingress/templates/controller-stats-service.yaml
+++ b/haproxy-ingress/templates/controller-stats-service.yaml
@@ -7,12 +7,12 @@ metadata:
 {{ toYaml .Values.controller.stats.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "haproxy-ingress.labels.app.controller" . }}
+    app: {{ include "haproxy-ingress.labels.app.controller" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}-stats
+  name: {{ include "haproxy-ingress.controller.fullname" . }}-stats
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.controller.stats.service.clusterIP }}
@@ -34,7 +34,7 @@ spec:
       port: {{ .Values.controller.stats.service.servicePort }}
       targetPort: stats
   selector:
-    app: {{ template "haproxy-ingress.labels.app.controller" . }}
+    app: {{ include "haproxy-ingress.labels.app.controller" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.stats.service.type }}"

--- a/haproxy-ingress/templates/controller-template.yaml
+++ b/haproxy-ingress/templates/controller-template.yaml
@@ -3,12 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}-template
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}-template
   namespace: {{ .Release.Namespace }}
 data:
   haproxy.tmpl: |-

--- a/haproxy-ingress/templates/controller-template.yaml
+++ b/haproxy-ingress/templates/controller-template.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}-template
+  name: {{ include "haproxy-ingress.controller.fullname" . }}-template
   namespace: {{ .Release.Namespace }}
 data:
   haproxy.tmpl: |-

--- a/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -3,18 +3,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.labels.app.default-backend" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "haproxy-ingress.defaultBackend.fullname" . }}
+  name: {{ include "haproxy-ingress.defaultBackend.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.defaultBackend.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "haproxy-ingress.labels.app.default-backend" . }}
+      app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
       component: "{{ .Values.defaultBackend.name }}"
       release: {{ .Release.Name }}
   template:
@@ -24,7 +24,7 @@ spec:
 {{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ template "haproxy-ingress.labels.app.default-backend" . }}
+        app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
         component: "{{ .Values.defaultBackend.name }}"
         release: {{ .Release.Name }}
         {{- if .Values.defaultBackend.podLabels }}

--- a/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.defaultBackend.enabled }}
+{{- if .Values.defaultBackend.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -3,20 +3,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.defaultBackend.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "haproxy-ingress.defaultBackend.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.defaultBackend.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.defaultBackend.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
-      component: "{{ .Values.defaultBackend.name }}"
-      release: {{ .Release.Name }}
+      {{- include "haproxy-ingress.defaultBackend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
     {{- if .Values.defaultBackend.podAnnotations }}
@@ -24,9 +18,7 @@ spec:
 {{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
-        component: "{{ .Values.defaultBackend.name }}"
-        release: {{ .Release.Name }}
+        {{- include "haproxy-ingress.defaultBackend.selectorLabels" . | nindent 8 }}
         {{- if .Values.defaultBackend.podLabels }}
 {{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
         {{- end }}

--- a/haproxy-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/haproxy-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -2,16 +2,16 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.labels.app.default-backend" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.defaultBackend.fullname" . }}
+  name: {{ include "haproxy-ingress.defaultBackend.fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "haproxy-ingress.labels.app.default-backend" . }}
+      app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
       release: {{ .Release.Name }}
       component: "{{ .Values.defaultBackend.name }}"
   minAvailable: {{ .Values.defaultBackend.minAvailable }}

--- a/haproxy-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/haproxy-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -2,16 +2,10 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.defaultBackend.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "haproxy-ingress.defaultBackend.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.defaultBackend.fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
-      release: {{ .Release.Name }}
-      component: "{{ .Values.defaultBackend.name }}"
+      {{- include "haproxy-ingress.defaultBackend.selectorLabels" . | nindent 6 }}
   minAvailable: {{ .Values.defaultBackend.minAvailable }}

--- a/haproxy-ingress/templates/default-backend-service.yaml
+++ b/haproxy-ingress/templates/default-backend-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.defaultBackend.enabled }}
+{{- if .Values.defaultBackend.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/haproxy-ingress/templates/default-backend-service.yaml
+++ b/haproxy-ingress/templates/default-backend-service.yaml
@@ -7,11 +7,7 @@ metadata:
 {{ toYaml .Values.defaultBackend.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.defaultBackend.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "haproxy-ingress.defaultBackend.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.defaultBackend.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -35,8 +31,6 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
-    component: "{{ .Values.defaultBackend.name }}"
-    release: {{ .Release.Name }}
+    {{- include "haproxy-ingress.defaultBackend.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.defaultBackend.service.type }}"
 {{- end }}

--- a/haproxy-ingress/templates/default-backend-service.yaml
+++ b/haproxy-ingress/templates/default-backend-service.yaml
@@ -7,12 +7,12 @@ metadata:
 {{ toYaml .Values.defaultBackend.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "haproxy-ingress.labels.app.default-backend" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.defaultBackend.fullname" . }}
+  name: {{ include "haproxy-ingress.defaultBackend.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.defaultBackend.service.clusterIP }}
@@ -35,7 +35,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    app: {{ template "haproxy-ingress.labels.app.default-backend" . }}
+    app: {{ include "haproxy-ingress.labels.app.default-backend" . }}
     component: "{{ .Values.defaultBackend.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.defaultBackend.service.type }}"

--- a/haproxy-ingress/templates/psp.yaml
+++ b/haproxy-ingress/templates/psp.yaml
@@ -2,10 +2,10 @@
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "haproxy-ingress.fullname" . }}
+  name: {{ include "haproxy-ingress.fullname" . }}
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:

--- a/haproxy-ingress/templates/psp.yaml
+++ b/haproxy-ingress/templates/psp.yaml
@@ -2,17 +2,14 @@
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ include "haproxy-ingress.fullname" . }}
-  labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  labels:
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}
 spec:
   privileged: true
   allowPrivilegeEscalation: true

--- a/haproxy-ingress/templates/psp.yaml
+++ b/haproxy-ingress/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.rbac.security.enable -}}
+{{- if .Values.rbac.security.enable -}}
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -39,4 +39,4 @@ spec:
   allowedHostPaths:
     - pathPrefix: /etc/haproxy/template
       readOnly: false
-{{ end -}}
+{{- end }}

--- a/haproxy-ingress/templates/role.yaml
+++ b/haproxy-ingress/templates/role.yaml
@@ -36,5 +36,5 @@ rules:
       - {{ include "haproxy-ingress.fullname" . }}
     verbs:
       - use
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/haproxy-ingress/templates/role.yaml
+++ b/haproxy-ingress/templates/role.yaml
@@ -3,11 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.fullname" . }}
+  name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
@@ -33,7 +33,7 @@ rules:
     resources:
       - podsecuritypolicies
     resourceNames:
-      - {{ template "haproxy-ingress.fullname" . }}
+      - {{ include "haproxy-ingress.fullname" . }}
     verbs:
       - use
 {{- end -}}

--- a/haproxy-ingress/templates/role.yaml
+++ b/haproxy-ingress/templates/role.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:

--- a/haproxy-ingress/templates/rolebinding.yaml
+++ b/haproxy-ingress/templates/rolebinding.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:

--- a/haproxy-ingress/templates/rolebinding.yaml
+++ b/haproxy-ingress/templates/rolebinding.yaml
@@ -20,4 +20,4 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: {{ include "haproxy-ingress.fullname" . }}
-{{- end -}}
+{{- end }}

--- a/haproxy-ingress/templates/rolebinding.yaml
+++ b/haproxy-ingress/templates/rolebinding.yaml
@@ -3,21 +3,21 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.fullname" . }}
+  name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "haproxy-ingress.fullname" . }}
+  name: {{ include "haproxy-ingress.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "haproxy-ingress.serviceAccountName" . }}
+    name: {{ include "haproxy-ingress.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
   - apiGroup: rbac.authorization.k8s.io
     kind: User
-    name: {{ template "haproxy-ingress.fullname" . }}
+    name: {{ include "haproxy-ingress.fullname" . }}
 {{- end -}}

--- a/haproxy-ingress/templates/serviceaccount.yaml
+++ b/haproxy-ingress/templates/serviceaccount.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/haproxy-ingress/templates/serviceaccount.yaml
+++ b/haproxy-ingress/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,4 +9,4 @@ metadata:
     heritage: {{ .Release.Service }}
   name: {{ include "haproxy-ingress.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}

--- a/haproxy-ingress/templates/serviceaccount.yaml
+++ b/haproxy-ingress/templates/serviceaccount.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.serviceAccountName" . }}
+  name: {{ include "haproxy-ingress.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/haproxy-ingress/templates/tcp-configmap.yaml
+++ b/haproxy-ingress/templates/tcp-configmap.yaml
@@ -4,12 +4,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "haproxy-ingress.name" . }}
-    chart: {{ template "haproxy-ingress.chart" . }}
+    app: {{ include "haproxy-ingress.name" . }}
+    chart: {{ include "haproxy-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}-tcp
+  name: {{ include "haproxy-ingress.controller.fullname" . }}-tcp
   namespace: {{ .Release.Namespace }}
 data:
 {{- range $key, $value := .Values.controller.tcp }}

--- a/haproxy-ingress/templates/tcp-configmap.yaml
+++ b/haproxy-ingress/templates/tcp-configmap.yaml
@@ -1,5 +1,4 @@
----
-{{- if .Values.controller.tcp }}
+{{- if .Values.controller.tcp -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/haproxy-ingress/templates/tcp-configmap.yaml
+++ b/haproxy-ingress/templates/tcp-configmap.yaml
@@ -3,12 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ include "haproxy-ingress.name" . }}
-    chart: {{ include "haproxy-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ include "haproxy-ingress.controller.fullname" . }}-tcp
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}-tcp
   namespace: {{ .Release.Namespace }}
 data:
 {{- range $key, $value := .Values.controller.tcp }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -12,11 +12,13 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+nameOverride: ""
+fullnameOverride: ""
+
 controller:
-  name: controller
   image:
     repository: quay.io/jcmoraisjr/haproxy-ingress
-    tag: "v0.7.2"
+    tag: v0.7.2
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []
@@ -164,10 +166,10 @@ controller:
 
   autoscaling:
     enabled: false
-  #  minReplicas: 1
-  #  maxReplicas: 11
-  #  targetCPUUtilizationPercentage: 50
-  #  targetMemoryUtilizationPercentage: 50
+    #  minReplicas: 1
+    #  maxReplicas: 11
+    #  targetCPUUtilizationPercentage: 50
+    #  targetMemoryUtilizationPercentage: 50
     customMetrics: []
 
   ## Node tolerations for server scheduling to nodes with taints


### PR DESCRIPTION
Partially redesign the chart based mostly on the chart v2 spec.

Changes:

* [x] A new `Chart.yaml` based on v2 spec
* [x] Group related named templates together in the template helpers
* [x] Use labels and selectorLabels as named templates
* [x] Value `controller.name` removed, all `haproxy-ingress.controller.*` named templates renamed to `haproxy-ingress.*`
* [x] Use `include` command instead of `template`
* [x] Fix small template formatting issues
* [x] Update post installation instructions