### PR TITLE
Update psp template to use new apiVersion.

### DIFF
--- a/haproxy-ingress/templates/psp.yaml
+++ b/haproxy-ingress/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.security.enable -}}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:


### PR DESCRIPTION
As of version 1.16 [kubernetes](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) has deprecated the `extensions/v1beta1` apiVersion for PodSecurityPolicy resources.

> PodSecurityPolicy in the extensions/v1beta1 API version
>
>    Migrate to use the policy/v1beta1 API, available since v1.10. Existing persisted data can be retrieved/updated via the new version.

This change updates the `templates/psp.yaml` to use the new apiVersion for PodSecurityPolicy resources.