### PR TITLE
Additional features: extra volumes, expose controller metrics port

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -75,9 +75,11 @@ Parameter | Description | Default
 `controller.image.tag` | controller container image tag | `v0.12-beta.2`
 `controller.image.pullPolicy` | controller container image pullPolicy | `IfNotPresent`
 `controller.imagePullSecrets` | controller image pull secrets | `[]`
-`controller.initContainers` | extra containers that can initialize the haproxy-ingress-controller | `[]`
 `controller.extraArgs` | extra command line arguments for the haproxy-ingress-controller | `{}`
-`controller.extraEnv` | extra environment variables for the haproxy-ingress-controller | `{}`
+`controller.extraEnvs` | extra environment variables for the haproxy-ingress-controller | `[]`
+`controller.extraVolumes` | extra volumes for the haproxy-ingress-controller | `[]`
+`controller.extraVolumeMounts` | extra volume mounts for the haproxy-ingress-controller | `[]`
+`controller.initContainers` | extra containers that can initialize the haproxy-ingress-controller | `[]`
 `controller.template` | custom template for haproxy-ingress-controller | `{}`
 `controller.defaultBackendService` | backend service to use if defaultBackend.enabled==false | `""`
 `controller.ingressClass` | name of the ingress class to route through this controller | `haproxy`

--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -158,6 +158,7 @@ Parameter | Description | Default
 `controller.metrics.enabled` | If `controller.stats.enabled = true` and `controller.metrics.enabled = true`, Prometheus metrics will be exported |  `false`
 `controller.metrics.embedded` | defines if embedded haproxy's exporter should be used | `true`
 `controller.metrics.port` | port number the exporter is listening to | `9101`
+`controller.metrics.controllerPort` | port number the controller is exporting metrics on | `10254`
 `controller.metrics.image.repository` | prometheus-exporter image repository when embedded is `false` | `quay.io/prometheus/haproxy-exporter`
 `controller.metrics.image.tag` | prometheus-exporter image tag | `v0.11.0`
 `controller.metrics.image.pullPolicy` | prometheus-exporter image pullPolicy | `IfNotPresent`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -68,7 +68,7 @@ spec:
 {{- if or (not .Values.controller.haproxy.enabled) .Values.controller.metrics.enabled }}
       ports:
   {{- if not .Values.controller.haproxy.enabled }}
-        {{- include "haproxy-ingress.controller.ports" . | nindent 8 }}
+        {{- include "haproxy-ingress.controller.ports" . | indent 8 }}
   {{- end }}
   {{- if .Values.controller.metrics.enabled }}
         - name: controller-metrics
@@ -129,7 +129,7 @@ spec:
     {{- end }}
   {{- end }}
       ports:
-        {{- include "haproxy-ingress.controller.ports" . | nindent 8 }}
+        {{- include "haproxy-ingress.controller.ports" . | indent 8 }}
       {{- include "haproxy-ingress.controller.probes" . | nindent 6 }}
       resources:
         {{- toYaml .Values.controller.haproxy.resources | nindent 8 }}
@@ -229,37 +229,37 @@ spec:
 
 {{- define "haproxy-ingress.controller.ports" -}}
 {{- if .Values.controller.enableStaticPorts }}
-  - name: http
-    containerPort: 80
+- name: http
+  containerPort: 80
   {{- if and (eq .Values.controller.kind "DaemonSet") .Values.controller.daemonset.useHostPort .Values.controller.daemonset.hostPorts.http }}
-    hostPort: {{ .Values.controller.daemonset.hostPorts.http }}
+  hostPort: {{ .Values.controller.daemonset.hostPorts.http }}
   {{- end }}
-  - name: https
-    containerPort: 443
+- name: https
+  containerPort: 443
   {{- if and (eq .Values.controller.kind "DaemonSet") .Values.controller.daemonset.useHostPort .Values.controller.daemonset.hostPorts.https }}
-    hostPort: {{ .Values.controller.daemonset.hostPorts.https }}
+  hostPort: {{ .Values.controller.daemonset.hostPorts.https }}
   {{- end }}
 {{- end }}
 {{- if and .Values.controller.metrics.enabled .Values.controller.metrics.embedded }}
-  - name: metrics
-    containerPort: {{ .Values.controller.metrics.port }}
-    protocol: TCP
+- name: metrics
+  containerPort: {{ .Values.controller.metrics.port }}
+  protocol: TCP
 {{- end }}
 {{- if .Values.controller.stats.enabled }}
-  - name: stats
-    containerPort: {{ .Values.controller.stats.port }}
-    protocol: TCP
+- name: stats
+  containerPort: {{ .Values.controller.stats.port }}
+  protocol: TCP
 {{- end }}
-  - name: healthz
-    containerPort: {{ .Values.controller.healthzPort }}
+- name: healthz
+  containerPort: {{ .Values.controller.healthzPort }}
 {{- range $key, $value := .Values.controller.tcp }}
-  - name: "{{ $key }}-tcp"
-    containerPort: {{ $key }}
-    protocol: TCP
+- name: "{{ $key }}-tcp"
+  containerPort: {{ $key }}
+  protocol: TCP
   {{- if and (eq $.Values.controller.kind "DaemonSet") $.Values.controller.daemonset.useHostPort }}
     {{- range $p := $.Values.controller.daemonset.hostPorts.tcp }}
       {{- if eq $key $p }}
-    hostPort: {{ $key }}
+  hostPort: {{ $key }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -81,7 +81,7 @@ spec:
 {{- if .Values.controller.extraEnvs }}
         {{- toYaml .Values.controller.extraEnvs | nindent 8 }}
 {{- end }}
-{{- if or .Values.controller.haproxy.enabled .Values.controller.template }}
+{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.extraVolumeMounts }}
       volumeMounts:
 {{- if .Values.controller.haproxy.enabled }}
         - mountPath: /etc/haproxy
@@ -94,6 +94,9 @@ spec:
 {{- if .Values.controller.template }}
         - name: haproxy-template
           mountPath: /etc/templates/haproxy
+{{- end }}
+{{- if .Values.controller.extraVolumeMounts }}
+        {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
 {{- end }}
 {{- end }}
       resources:
@@ -126,6 +129,9 @@ spec:
           name: lib
         - mountPath: /var/run/haproxy
           name: run
+{{- if .Values.controller.extraVolumeMounts }}
+        {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
+{{- end }}
 {{- end }}
 {{- if .Values.controller.logs.enabled }}
     - name: access-logs
@@ -167,7 +173,7 @@ spec:
   imagePullSecrets:
     {{- toYaml .Values.controller.imagePullSecrets | nindent 4 }}
 {{- end }}
-{{- if or .Values.controller.haproxy.enabled .Values.controller.template }}
+{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.extraVolumes }}
   volumes:
 {{- if .Values.controller.haproxy.enabled }}
     - name: etc
@@ -181,6 +187,9 @@ spec:
     - name: haproxy-template
       configMap:
         name: {{ include "haproxy-ingress.fullname" . }}-template
+{{- end }}
+{{- if .Values.controller.extraVolumes }}
+    {{- toYaml .Values.controller.extraVolumes | nindent 4 }}
 {{- end }}
 {{- end }}
   terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -77,7 +77,7 @@ spec:
   {{- end }}
 {{- end }}
 {{- if not .Values.controller.haproxy.enabled }}
-      {{- include "haproxy-ingress.controller.probes" . | nindent 6 }}
+      {{- include "haproxy-ingress.controller.probes" . | indent 6 }}
 {{- end }}
       env:
         - name: POD_NAME
@@ -130,7 +130,7 @@ spec:
   {{- end }}
       ports:
         {{- include "haproxy-ingress.controller.ports" . | indent 8 }}
-      {{- include "haproxy-ingress.controller.probes" . | nindent 6 }}
+      {{- include "haproxy-ingress.controller.probes" . | indent 6 }}
       resources:
         {{- toYaml .Values.controller.haproxy.resources | nindent 8 }}
       volumeMounts:
@@ -227,7 +227,7 @@ spec:
 {{- end }}
 {{- end }}
 
-{{- define "haproxy-ingress.controller.ports" -}}
+{{- define "haproxy-ingress.controller.ports" }}
 {{- if .Values.controller.enableStaticPorts }}
 - name: http
   containerPort: 80
@@ -266,7 +266,7 @@ spec:
 {{- end }}
 {{- end }}
 
-{{- define "haproxy-ingress.controller.probes" -}}
+{{- define "haproxy-ingress.controller.probes" }}
 livenessProbe:
   httpGet:
     path: {{ .Values.controller.livenessProbe.path | quote }}

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -65,8 +65,18 @@ spec:
         - --{{ $key }}
   {{- end }}
 {{- end }}
+{{- if or (not .Values.controller.haproxy.enabled) .Values.controller.metrics.enabled }}
+      ports:
+  {{- if not .Values.controller.haproxy.enabled }}
+        {{- include "haproxy-ingress.controller.ports" . | nindent 8 }}
+  {{- end }}
+  {{- if .Values.controller.metrics.enabled }}
+        - name: controller-metrics
+          containerPort: {{ .Values.controller.metrics.controllerPort }}
+          protocol: TCP
+  {{- end }}
+{{- end }}
 {{- if not .Values.controller.haproxy.enabled }}
-      {{- include "haproxy-ingress.controller.ports" . | nindent 6 }}
       {{- include "haproxy-ingress.controller.probes" . | nindent 6 }}
 {{- end }}
       env:
@@ -118,7 +128,8 @@ spec:
         - --{{ $key }}
     {{- end }}
   {{- end }}
-      {{- include "haproxy-ingress.controller.ports" . | nindent 6 }}
+      ports:
+        {{- include "haproxy-ingress.controller.ports" . | nindent 8 }}
       {{- include "haproxy-ingress.controller.probes" . | nindent 6 }}
       resources:
         {{- toYaml .Values.controller.haproxy.resources | nindent 8 }}
@@ -217,7 +228,6 @@ spec:
 {{- end }}
 
 {{- define "haproxy-ingress.controller.ports" -}}
-ports:
 {{- if .Values.controller.enableStaticPorts }}
   - name: http
     containerPort: 80

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -42,6 +42,10 @@ controller:
   #         key: FOO
   #         name: secret-resource
 
+  ## Additional volumes and volume mounts
+  extraVolumes: []
+  extraVolumeMounts: []
+
   ## Additional containers that can initialize the pod.
   initContainers: []
 

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -278,6 +278,10 @@ controller:
     # Port number the exporter is listening to
     port: 9101
 
+    # The port the controller exports metrics on.
+    # If you change it here, you must also change it using the controller.extraArgs.
+    controllerPort: 10254
+
     # prometheus exporter for haproxy
     # https://github.com/prometheus/haproxy_exporter
     # (scrapes the stats port and exports metrics to prometheus)


### PR DESCRIPTION
Hi, I added the ability to mount extra volumes. This can be useful together with csi-secrets-storage-provider-azure to mount a TLS cert as a volume, and as a side-effect create a synced secret with the TLS cert that can be used to specify the cert for the default backend.

Also exposed the controller metrics port so that Prometheus can scrape those metrics when metrics are enabled. (I used to have this in my local version of this chart.)