### PR TITLE
Shorten name of controller metrics port

### DIFF
--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -71,7 +71,7 @@ spec:
         {{- include "haproxy-ingress.controller.ports" . | indent 8 }}
   {{- end }}
   {{- if .Values.controller.metrics.enabled }}
-        - name: controller-metrics
+        - name: ctrl-metrics
           containerPort: {{ .Values.controller.metrics.controllerPort }}
           protocol: TCP
   {{- end }}


### PR DESCRIPTION
Hi @jcmoraisjr, I'm sorry but the port name I used in my last PR #11 was too long:

```
spec.template.spec.containers[0].ports[3].name: Invalid value: "controller-metrics": must be no more than 15 characters
```