### PR TITLE
Expose the controller metrics port on the metrics service

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -170,6 +170,7 @@ Parameter | Description | Default
 `controller.metrics.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.metrics.service.loadBalancerSourceRanges` |  | `[]`
 `controller.metrics.service.servicePort` | the port number exposed by the metrics service | `9101`
+`controller.metrics.service.serviceControllerPort` | the controller port number exposed by the metrics service | `10254`
 `controller.metrics.service.type` | type of controller service to create | `ClusterIP`
 `controller.serviceMonitor.enabled` | Enable creation of ServiceMonitor (https://coreos.com/operators/prometheus/docs/latest/api.html#servicemonitor). This has effect only when `controller.stats.enabled = true` and `controller.metrics.enabled = true` | `false`
 `controller.serviceMonitor.labels` | Additional labels for the ServiceMonitor resource | `{}`

--- a/haproxy-ingress/templates/controller-metrics-service.yaml
+++ b/haproxy-ingress/templates/controller-metrics-service.yaml
@@ -32,6 +32,9 @@ spec:
     - name: metrics
       port: {{ .Values.controller.metrics.service.servicePort }}
       targetPort: metrics
+    - name: ctrl-metrics
+      port: {{ .Values.controller.metrics.service.serviceControllerPort }}
+      targetPort: ctrl-metrics
   selector:
     {{- include "haproxy-ingress.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.controller.metrics.service.type }}"

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -320,6 +320,7 @@ controller:
       loadBalancerIP: ""
       loadBalancerSourceRanges: []
       servicePort: 9101
+      serviceControllerPort: 10254
       type: ClusterIP
 
   ## If controller.stats.enabled = true and controller.metrics.enabled = true and controller.serviceMonitor.enabled = true, Prometheus ServiceMonitor will be created


### PR DESCRIPTION
The controller metrics port needs to be exposed by the metrics service, so that Prometheus can scrape it.