### PR TITLE
Add controller metrics port to service monitor

### DIFF
--- a/haproxy-ingress/templates/controller-servicemonitor.yaml
+++ b/haproxy-ingress/templates/controller-servicemonitor.yaml
@@ -19,6 +19,10 @@ spec:
     interval: {{ .Values.controller.serviceMonitor.interval }}
     path: /metrics
     port: metrics
+  - honorLabels: {{ .Values.controller.serviceMonitor.honorLabels }}
+    interval: {{ .Values.controller.serviceMonitor.interval }}
+    path: /metrics
+    port: ctrl-metrics
   jobLabel: app.kubernetes.io/name
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
Right now only the haproxy metrics are picked up by the service monitor. This adds the controller metrics as well.

I think this should work whether the metrics service is using the embedded option or not but I've only tested it with embedded metrics.