### PR TITLE
Add template function to config properties

### DIFF
--- a/haproxy-ingress/templates/controller-configmap.yaml
+++ b/haproxy-ingress/templates/controller-configmap.yaml
@@ -18,5 +18,5 @@ data:
   syslog-format: "raw"
 {{- end }}
 {{- if .Values.controller.config }}
-  {{- toYaml .Values.controller.config | nindent 2 }}
+  {{- tpl (toYaml .Values.controller.config) . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Added the template (`tpl`) function to the `.Values.controller.config` properties, so things like `{{ .Release.Namespace }}` works.

The `tpl` function is also used for the [TCP ConfigMap](https://github.com/haproxy-ingress/charts/blob/master/haproxy-ingress/templates/tcp-configmap.yaml#L11), so added the same logic here. 