### PR TITLE
Add volume mounts to access-logs sidecar container

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -211,6 +211,7 @@ Parameter | Description | Default
 `controller.logs.image.repository` | access-logs container image repository | `whereisaaron/kube-syslog-sidecar`
 `controller.logs.image.tag` | access-logs image tag | `latest`
 `controller.logs.image.pullPolicy` | access-logs image pullPolicy | `IfNotPresent`
+`controller.logs.extraVolumeMounts` | extra volume mounts for the access-logs container | `[]`
 `controller.logs.resources` | access-logs container resource requests & limits |  `{}`
 `defaultBackend.enabled` | whether to use the default backend component | `false`
 `defaultBackend.name` | name of the default backend component | `default-backend`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -152,6 +152,10 @@ spec:
         - name: udp
           containerPort: 514
           protocol: UDP
+{{- if .Values.controller.logs.extraVolumeMounts }}
+      volumeMounts:
+        {{- toYaml .Values.controller.logs.extraVolumeMounts | nindent 8 }}
+{{- end }}
       resources:
         {{- toYaml .Values.controller.logs.resources | nindent 8 }}
 {{- end }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -364,6 +364,9 @@ controller:
       tag: latest
       pullPolicy: IfNotPresent
 
+    ## Additional volume mounts
+    extraVolumeMounts: []
+
     resources: {}
     #  limits:
     #    cpu: 200m


### PR DESCRIPTION
This adds the option to do volume mounts also for the access-logs sidecar container. With that i could mount a zoneinfo file to have correct timezone also in access-logs container. I already was able to do so for the haproxy-ingress container, but we want to have the correct timestamp also for the access-log container. Right now the logs contain two different timestamps. In our use case we want to have both timestamps correct.