### PR TITLE
Restore the defaults for targetPort when not explicitly set

### DIFF
--- a/haproxy-ingress/templates/controller-service.yaml
+++ b/haproxy-ingress/templates/controller-service.yaml
@@ -52,7 +52,7 @@ spec:
     - name: "http-{{ .port }}"
       port: {{ .port }}
       protocol: TCP
-      targetPort: {{ .targetPort }}
+      targetPort: {{ .targetPort | default "http" }}
     {{- if (not (empty .nodePort)) }}
       nodePort: {{ .nodePort }}
     {{- end }}
@@ -61,7 +61,7 @@ spec:
     - name: "https-{{ .port }}"
       port: {{ .port }}
       protocol: TCP
-      targetPort: {{ .targetPort }}
+      targetPort: {{ .targetPort | default "https" }}
     {{- if (not (empty .nodePort)) }}
       nodePort: {{ .nodePort }}
     {{- end }}


### PR DESCRIPTION
The original intent with having separate `httpPorts` and `httpsPorts` was to be able to specify multiple ports of each kind, mapped to the `http` and `https` ports, respectively, on the haproxy-ingress pod. When the ability to set the `targetPort` was added by https://github.com/haproxy-ingress/charts/commit/00ce05399db68257bd9906c397760ed053904f52, backwards compatibility was broken by removing the defaults.

Fixes #25