### PR TITLE
Add 'controller.service.extraPorts' functionality

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -170,6 +170,7 @@ Parameter | Description | Default
 `controller.service.clusterIPs` | list of internal controller cluster service IPs (for dual-stack) | `[]`
 `controller.service.externalTrafficPolicy` | If `controller.service.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport) | `Local`
 `controller.service.externalIPs` | list of IP addresses at which the controller services are available | `[]`
+`controller.service.extraPorts` | list of extra TCP ports that should be added to the controller service | `[]`
 `controller.service.ipFamilies` | list of IP families assigned to the service (for dual-stack) | `nil`
 `controller.service.ipFamilyPolicy` | represents the dual-stack-ness of the service | `nil`
 `controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`

--- a/haproxy-ingress/templates/controller-service.yaml
+++ b/haproxy-ingress/templates/controller-service.yaml
@@ -73,6 +73,15 @@ spec:
       protocol: TCP
       targetPort: "{{ tpl $key $ }}-tcp"
 {{- end }}
+{{- range $row := .Values.controller.service.extraPorts }}
+    - name: "extra-port-{{ $row.port }}"
+      port: {{ $row.port }}
+      protocol: TCP
+      targetPort: {{ $row.targetPort }}
+    {{- if (not (empty $row.nodePort)) }}
+      nodePort: {{ $row.nodePort }}
+    {{- end }}
+{{- end }}
   selector:
     {{- include "haproxy-ingress.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.controller.service.type }}"

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -228,6 +228,14 @@ controller:
         targetPort: https
       # nodePort:
 
+    ## Add extra ports to the service
+    ## Useful when adding the 'tcp-service-port' configuration key
+    ## Ref: https://haproxy-ingress.github.io/v0.13/docs/configuration/keys/#tcp-services
+    extraPorts: []
+    # - port: 8080
+    #   targetPort: 8080
+    #   nodePort: 30012
+
     ## Set external traffic policy to: "Local" to preserve source IP on
     ## providers supporting it
     ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer


### PR DESCRIPTION
The extraPorts will add custom ports to the service.

This functionality is added because of the new [tcp-service-port](https://haproxy-ingress.github.io/v0.13/docs/configuration/keys/#tcp-services) functionality in v0.13, which doesn't update the service automatically, because it's an ingress annotation.

In my opinion this has the benefit of creating a TCP service in HAProxy, which isn't automatically exposed to the service, and can be useful for internal TCP proxies.