### PR TITLE
Configurable lifecycle hooks for controller container

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -141,6 +141,7 @@ Parameter | Description | Default
 `controller.hostNetwork` | Optionally set to true when using CNI based kubernetes installations | `false`
 `controller.dnsPolicy` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' | `ClusterFirst`
 `controller.terminationGracePeriodSeconds` | How much to wait before terminating a pod (in seconds) | `60`
+`controller.lifecycle` | Lifecycle hooks for controller container | `{}`
 `controller.kind` | Type of deployment, DaemonSet or Deployment | `Deployment`
 `controller.tcp` | TCP [service ConfigMap](https://haproxy-ingress.github.io/docs/configuration/command-line/#tcp-services-configmap): `<port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]` | `{}`
 `controller.enableStaticPorts` | Set to `false` to only rely on ports from `controller.tcp` | `true`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -111,6 +111,10 @@ spec:
 {{- end }}
       resources:
         {{- toYaml .Values.controller.resources | nindent 8 }}
+{{- if .Values.controller.lifecycle }}
+      lifecycle:
+        {{- toYaml .Values.controller.lifecycle | nindent 8 }}
+{{- end }}
 {{- if .Values.controller.haproxy.enabled }}
     - name: haproxy
       image: "{{ .Values.controller.haproxy.image.repository }}:{{ .Values.controller.haproxy.image.tag }}"

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -126,6 +126,12 @@ controller:
   # How many seconds to wait before terminating a pod.
   terminationGracePeriodSeconds: 60
 
+  # Configure container lifecycle. When scaling replicas down this can be
+  # used to prevent controller container from terminating quickly and drop in-flight requests.
+  # For example, when the controller runs behind Network Load Balancer this can be used
+  # to configure preStop hook to sleep along with deregistration_delay.
+  lifecycle: {}
+
   ## DaemonSet or Deployment
   ##
   kind: Deployment


### PR DESCRIPTION
**Context for this change**
haproxy-ingress controller runs behind NLB on AWS with VPC CNI , where haproxy-ingress Pods gets IP from VPC CIDRs and gets added as targets in NLB target group. 

I need to be able to configure `lifecycle` to keep the pod around (by making it `sleep`) at least until NLB's `deregistration_delay` - so that in-flight requests can be served by haproxy-ingress Pods whenever replica counts are reduced. 

This change is tested - without the lifecycle hook I see traffic gets dropped on reducing replica count.


**Question regarding this change**
As per [doc](https://haproxy-ingress.github.io/v0.13/docs/configuration/keys/#acme) leader election is used for cert management. Does keeping terminating pod longer through lifecycle affect the leader election and correctness when it comes to cert management? 