### PR TITLE
Allow passing extra parameters to HAProxy

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -210,8 +210,7 @@ Parameter | Description | Default
 `controller.serviceMonitor.annotations` | Annotations for ServiceMonitor resource | `{}`
 `controller.serviceMonitor.honorLabels` | HonorLabels chooses the metric's labels on collisions with target labels | `true`
 `controller.serviceMonitor.interval` | Prometheus scrape interval | `10s`
-`controller.serviceMonitor.params.enabled` | Enables extra parameters from Prometheus when requesting metrics | `false`
-`controller.serviceMonitor.params.conf` | Extra parameters for Prometheus requests, as described in the ServiceMonitor API | `false`
+`controller.serviceMonitor.params` | Use extra parameters from Prometheus when requesting metrics | `false`
 `controller.logs.enabled` | enable an access-logs sidecar container that collects access logs from haproxy and outputs to stdout | `false`
 `controller.logs.image.repository` | access-logs container image repository | `whereisaaron/kube-syslog-sidecar`
 `controller.logs.image.tag` | access-logs image tag | `latest`

--- a/haproxy-ingress/templates/controller-servicemonitor.yaml
+++ b/haproxy-ingress/templates/controller-servicemonitor.yaml
@@ -19,9 +19,9 @@ spec:
     interval: {{ .Values.controller.serviceMonitor.interval }}
     path: /metrics
     port: metrics
-    {{- if .Values.controller.serviceMonitor.params.enabled }}
+    {{- if .Values.controller.serviceMonitor.params }}
     params:
-      {{- toYaml .Values.controller.serviceMonitor.params.conf | nindent 6 }}
+      {{- toYaml .Values.controller.serviceMonitor.params | nindent 6 }}
     {{- end }}
   - honorLabels: {{ .Values.controller.serviceMonitor.honorLabels }}
     interval: {{ .Values.controller.serviceMonitor.interval }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -368,11 +368,9 @@ controller:
     interval: 10s
 
     # Prometheus request extra parameters
-    params:
-      enabled: false
-      conf:
-        # no-maint:
-        # - empty
+    # params:
+    #   no-maint:
+    #   - empty
 
   ## access-logs side-car container for collecting haproxy logs
   ## Enabling this will configure haproxy to emit logs to syslog localhost:514 UDP port.


### PR DESCRIPTION
This will allow passing parameters like no-maint=empty requesting filtered metrics, limiting the amount of metrics pulled by Prometheus.

https://github.com/haproxy/haproxy/blob/master/addons/promex/README