### PR TITLE
Feature/topology spread constraints fixes #40

### DIFF
--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -244,6 +244,7 @@ spec:
 {{- end }}
 {{- end }}
   terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
+  topologySpreadConstraints: {{ .Values.controller.topologySpreadConstraints }}
   dnsPolicy: {{ .Values.controller.dnsPolicy }}
   hostNetwork: {{ .Values.controller.hostNetwork }}
 {{- if .Values.controller.nodeSelector }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -140,6 +140,19 @@ controller:
   # How many seconds to wait before terminating a pod.
   terminationGracePeriodSeconds: 60
 
+  # topology spread constraints to be added to the controller pods
+  # - the example below may need match labels adjusted but would
+  #   cause the pods to be spread across all available pods
+  # (requires kubernetes v1.19 or later)
+  topologySpreadConstraints: {}
+  #  - maxSkew: 1
+  #    topologyKey: kubernetes.io/hostname
+  #    whenUnsatisfiable: ScheduleAnyway
+  #    labelSelector:
+  #      matchLabels:
+  #        app.kubernetes.io/name: haproxy-ingress
+  #        app.kubernetes.io/instance: haproxy
+
   # Configure container lifecycle. When scaling replicas down this can be
   # used to prevent controller container from terminating quickly and drop in-flight requests.
   # For example, when the controller runs behind Network Load Balancer this can be used


### PR DESCRIPTION
I think this solves the problem; the one concern I have is since topologySpreadConstraint was added in kubernetes 1.19, I'm not sure if having it there will be a problem for earlier versions; I *think* it will just ignore it possibly with a warning, but I'm not sure.

If that is a problem then we'd just need to change the template to not include it if it's empty from values, but I don't know how to do that -- I was just copying patterns from elsewhere in the template.