### PR TITLE
Add support for Prometheus metricRelabelings

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -219,6 +219,7 @@ Parameter | Description | Default
 `controller.serviceMonitor.annotations` | Annotations for ServiceMonitor resource | `{}`
 `controller.serviceMonitor.honorLabels` | HonorLabels chooses the metric's labels on collisions with target labels | `true`
 `controller.serviceMonitor.interval` | Prometheus scrape interval | `10s`
+`controller.serviceMonitor.metricRelabelings` | Prometheus metric_relabel_configs for tweaking scraped metrics | `false`
 `controller.serviceMonitor.params` | Use extra parameters from Prometheus when requesting metrics | `false`
 `controller.logs.enabled` | enable an access-logs sidecar container that collects access logs from haproxy and outputs to stdout | `false`
 `controller.logs.image.repository` | access-logs container image repository | `whereisaaron/kube-syslog-sidecar`

--- a/haproxy-ingress/templates/controller-servicemonitor.yaml
+++ b/haproxy-ingress/templates/controller-servicemonitor.yaml
@@ -19,6 +19,10 @@ spec:
     interval: {{ .Values.controller.serviceMonitor.interval }}
     path: /metrics
     port: metrics
+    {{- if .Values.controller.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml .Values.controller.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
     {{- if .Values.controller.serviceMonitor.params }}
     params:
       {{- toYaml .Values.controller.serviceMonitor.params | nindent 6 }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -413,6 +413,13 @@ controller:
     #   no-maint:
     #   - empty
 
+    # Prometheus metric_relabel_configs
+    # metricRelabelings:
+    #   - sourceLabels:
+    #       - __name__
+    #     regex: haproxy_server_bytes.*
+    #     action: drop
+
   ## access-logs side-car container for collecting haproxy logs
   ## Enabling this will configure haproxy to emit logs to syslog localhost:514 UDP port.
   ## The access-logs container starts a syslog process that listens on UDP 514 and outputs to stdout.


### PR DESCRIPTION
Add an option to the ServiceMonitor to support metricRelabelings. This
allows post-scrape metric filtering and munging.

Signed-off-by: SuperQ <superq@gmail.com>