### PR TITLE
fix: serviceMonitor selector matchLabels

### DIFF
--- a/haproxy-ingress/templates/controller-servicemonitor.yaml
+++ b/haproxy-ingress/templates/controller-servicemonitor.yaml
@@ -33,6 +33,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: haproxy-ingress
+      {{- include "haproxy-ingress.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: metrics
 {{- end }}


### PR DESCRIPTION
# Description
Service monitor selectors are static and do not update based on chart values.

This PR ensure the service monitor labels follow the configured parameters and only monitors the correct release.

# Test
1. Run:
  ```sh
  helm template ./haproxy-ingress \
    --set=nameOverride=haproxy-test \
    --set=controller.metrics.enabled=true \
    --set=controller.serviceMonitor.enabled=true
  ```
2. Check that `matchLabels:` for `ServiceMonitor` object match accordingly:
```yaml
# Source: haproxy-ingress/templates/controller-servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  labels:
    helm.sh/chart: haproxy-ingress-0.13.5
    app.kubernetes.io/name: haproxy-test
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "v0.13.5"
    app.kubernetes.io/managed-by: Helm
  name: RELEASE-NAME-haproxy-test
[...]
  selector:
    matchLabels:
      app.kubernetes.io/name: haproxy-test
      app.kubernetes.io/instance: RELEASE-NAME
      app.kubernetes.io/component: metrics
```