### PR TITLE
Added hostIP configuration option

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -154,6 +154,7 @@ Parameter | Description | Default
 `controller.tcp` | TCP [service ConfigMap](https://haproxy-ingress.github.io/docs/configuration/command-line/#tcp-services-configmap): `<port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]` | `{}`
 `controller.enableStaticPorts` | Set to `false` to only rely on ports from `controller.tcp` | `true`
 `controller.daemonset.useHostPort` | Set to true to use host ports 80 and 443 | `false`
+`controller.daemonset.hostIP` | Change the IP the host ports will bind to | `nil`
 `controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty sets the hostPort for http | `"80"`
 `controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty sets the hostPort for https | `"443"`
 `controller.daemonset.hostPorts.tcp` | If `controller.daemonset.useHostPort` is `true` use hostport for these ports from `tcp` | `[]`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -280,21 +280,21 @@ spec:
 {{- if .Values.controller.enableStaticPorts }}
 - name: http
   containerPort: 80
-  {{- if and (eq .Values.controller.kind "DaemonSet") .Values.controller.daemonset.useHostPort }}
+  {{- if eq .Values.controller.kind "DaemonSet" }}
     {{- if .Values.controller.daemonset.hostIP }}
   hostIP: {{ .Values.controller.daemonset.hostIP }}
     {{- end }}
-    {{- if .Values.controller.daemonset.hostPorts.http }}
+    {{- if and .Values.controller.daemonset.useHostPort .Values.controller.daemonset.hostPorts.http }}
   hostPort: {{ .Values.controller.daemonset.hostPorts.http }}
     {{- end }}
   {{- end }}
 - name: https
   containerPort: 443
-  {{- if and (eq .Values.controller.kind "DaemonSet") .Values.controller.daemonset.useHostPort }}
+  {{- if eq .Values.controller.kind "DaemonSet" }}
     {{- if .Values.controller.daemonset.hostIP }}
   hostIP: {{ .Values.controller.daemonset.hostIP }}
     {{- end }}
-    {{- if .Values.controller.daemonset.hostPorts.https }}
+    {{- if and .Values.controller.daemonset.useHostPort .Values.controller.daemonset.hostPorts.https }}
   hostPort: {{ .Values.controller.daemonset.hostPorts.https }}
     {{- end }}
   {{- end }}
@@ -315,13 +315,15 @@ spec:
 - name: "{{ $key }}-tcp"
   containerPort: {{ $key }}
   protocol: TCP
-  {{- if and (eq $.Values.controller.kind "DaemonSet") $.Values.controller.daemonset.useHostPort }}
+  {{- if eq $.Values.controller.kind "DaemonSet" }}
     {{- if $.Values.controller.daemonset.hostIP }}
   hostIP: {{ $.Values.controller.daemonset.hostIP }}
     {{- end }}
-    {{- range $p := $.Values.controller.daemonset.hostPorts.tcp }}
-      {{- if eq $key $p }}
+    {{- if $.Values.controller.daemonset.useHostPort }}
+      {{- range $p := $.Values.controller.daemonset.hostPorts.tcp }}
+        {{- if eq $key $p }}
   hostPort: {{ $key }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -280,13 +280,23 @@ spec:
 {{- if .Values.controller.enableStaticPorts }}
 - name: http
   containerPort: 80
-  {{- if and (eq .Values.controller.kind "DaemonSet") .Values.controller.daemonset.useHostPort .Values.controller.daemonset.hostPorts.http }}
+  {{- if and (eq .Values.controller.kind "DaemonSet") .Values.controller.daemonset.useHostPort }}
+    {{- if .Values.controller.daemonset.hostIP }}
+  hostIP: {{ .Values.controller.daemonset.hostIP }}
+    {{- end }}
+    {{- if .Values.controller.daemonset.hostPorts.http }}
   hostPort: {{ .Values.controller.daemonset.hostPorts.http }}
+    {{- end }}
   {{- end }}
 - name: https
   containerPort: 443
-  {{- if and (eq .Values.controller.kind "DaemonSet") .Values.controller.daemonset.useHostPort .Values.controller.daemonset.hostPorts.https }}
+  {{- if and (eq .Values.controller.kind "DaemonSet") .Values.controller.daemonset.useHostPort }}
+    {{- if .Values.controller.daemonset.hostIP }}
+  hostIP: {{ .Values.controller.daemonset.hostIP }}
+    {{- end }}
+    {{- if .Values.controller.daemonset.hostPorts.https }}
   hostPort: {{ .Values.controller.daemonset.hostPorts.https }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- if and .Values.controller.metrics.enabled .Values.controller.metrics.embedded }}
@@ -306,6 +316,9 @@ spec:
   containerPort: {{ $key }}
   protocol: TCP
   {{- if and (eq $.Values.controller.kind "DaemonSet") $.Values.controller.daemonset.useHostPort }}
+    {{- if $.Values.controller.daemonset.hostIP }}
+  hostIP: {{ $.Values.controller.daemonset.hostIP }}
+    {{- end }}
     {{- range $p := $.Values.controller.daemonset.hostPorts.tcp }}
       {{- if eq $key $p }}
   hostPort: {{ $key }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -71,7 +71,7 @@ controller:
   ingressClassResource:
     enabled: false
     default: false
-    controllerClass: ''
+    controllerClass: ""
     parameters: {}
 
   healthzPort: 10253
@@ -176,10 +176,16 @@ controller:
   # optionally disable static ports, including the default 80 and 443
   enableStaticPorts: true
 
-  ## Use host ports 80 and 443
+  ## DaemonSet configuration
   daemonset:
+    # Enable binding ports to the host machine
     useHostPort: false
 
+    # IP to bind host ports to
+    hostIP: null
+    # hostIP: 10.1.0.1
+
+    # Ports to bind to the host
     hostPorts:
       http: 80
       https: 443


### PR DESCRIPTION
In my setup, I use host ports to expose the ingress on bare metal. However, to expose an ingress for internal usage, I needed a way to bind haproxy to a specific ip. This PR adds the ability to do that.

**Changes:**
- Extended the DaemonSet host port options to allow binding to a specific ip.