### PR TITLE
control-servicemonitor: Replace hardcoded matchLabels.

### DIFF
--- a/haproxy-ingress/templates/controller-servicemonitor.yaml
+++ b/haproxy-ingress/templates/controller-servicemonitor.yaml
@@ -33,6 +33,5 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: haproxy-ingress
-      app.kubernetes.io/component: metrics
+      {{- include "haproxy-ingress.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
The original setup here resulted in the serviceMonitor always expecting
and targeting an `haproxy-ingress` deployment, which is a problem if you
have multiple releases of this chart deployed to a single namespace.