### PR TITLE
improve custom template handling

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -109,7 +109,7 @@ Parameter | Description | Default
 `controller.extraContainers` | extra containers that to the haproxy-ingress-controller | `[]`
 `controller.initContainers` | extra containers that can initialize the haproxy-ingress-controller | `[]`
 `controller.template` | custom template for haproxy-ingress-controller | `{}`
-`controller.templateFile` | custom haproxy template path for haproxy-ingress-controller | `{}`
+`controller.templateFile` | custom haproxy template path for haproxy-ingress-controller | `""`
 `controller.defaultBackendService` | backend service to use if defaultBackend.enabled==false | `""`
 `controller.ingressClass` | name of the ingress class to route through this controller | `haproxy`
 `controller.ingressClassResource.enabled` | create an [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) resource for this controller | `false`

--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -108,7 +108,7 @@ Parameter | Description | Default
 `controller.extraVolumeMounts` | extra volume mounts for the haproxy-ingress-controller | `[]`
 `controller.extraContainers` | extra containers that to the haproxy-ingress-controller | `[]`
 `controller.initContainers` | extra containers that can initialize the haproxy-ingress-controller | `[]`
-`controller.template` | custom template for haproxy-ingress-controller | `{}`
+`controller.template` | custom template for haproxy-ingress-controller | `false`
 `controller.defaultBackendService` | backend service to use if defaultBackend.enabled==false | `""`
 `controller.ingressClass` | name of the ingress class to route through this controller | `haproxy`
 `controller.ingressClassResource.enabled` | create an [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) resource for this controller | `false`

--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -108,7 +108,8 @@ Parameter | Description | Default
 `controller.extraVolumeMounts` | extra volume mounts for the haproxy-ingress-controller | `[]`
 `controller.extraContainers` | extra containers that to the haproxy-ingress-controller | `[]`
 `controller.initContainers` | extra containers that can initialize the haproxy-ingress-controller | `[]`
-`controller.template` | custom template for haproxy-ingress-controller | `false`
+`controller.template` | custom template for haproxy-ingress-controller | `{}`
+`controller.templateFile` | custom haproxy template path for haproxy-ingress-controller | `{}`
 `controller.defaultBackendService` | backend service to use if defaultBackend.enabled==false | `""`
 `controller.ingressClass` | name of the ingress class to route through this controller | `haproxy`
 `controller.ingressClassResource.enabled` | create an [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) resource for this controller | `false`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -1,7 +1,7 @@
 {{- define "haproxy-ingress.controller.podTemplate" -}}
 metadata:
   annotations:
-{{- if .Values.controller.template }}
+{{- if or .Values.controller.template .Values.controller.templateFile }}
     checksum/config: {{ include (print $.Template.BasePath "/controller-template.yaml") . | sha256sum }}
 {{- end }}
 {{- if .Values.controller.podAnnotations }}
@@ -94,7 +94,7 @@ spec:
 {{- if .Values.controller.extraEnvs }}
         {{- toYaml .Values.controller.extraEnvs | nindent 8 }}
 {{- end }}
-{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.extraVolumeMounts }}
+{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.templateFile .Values.controller.extraVolumeMounts }}
       volumeMounts:
 {{- if .Values.controller.haproxy.enabled }}
         - mountPath: /etc/haproxy
@@ -104,7 +104,7 @@ spec:
         - mountPath: /var/run/haproxy
           name: run
 {{- end }}
-{{- if .Values.controller.template }}
+{{- if or .Values.controller.template .Values.controller.templateFile }}
         - name: haproxy-template
           mountPath: /etc/templates/haproxy
 {{- end }}
@@ -226,7 +226,7 @@ spec:
   imagePullSecrets:
     {{- toYaml .Values.controller.imagePullSecrets | nindent 4 }}
 {{- end }}
-{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.extraVolumes }}
+{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.templateFile .Values.controller.extraVolumes }}
   volumes:
 {{- if .Values.controller.haproxy.enabled }}
     - name: etc
@@ -236,7 +236,7 @@ spec:
     - name: run
       emptyDir: {}
 {{- end }}
-{{- if .Values.controller.template }}
+{{- if or .Values.controller.template .Values.controller.templateFile }}
     - name: haproxy-template
       configMap:
         name: {{ include "haproxy-ingress.fullname" . }}-template

--- a/haproxy-ingress/templates/controller-template.yaml
+++ b/haproxy-ingress/templates/controller-template.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.template -}}
+{{- if or .Values.controller.template .Values.controller.templateFile -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,6 +8,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   haproxy.tmpl: |
-{{/* .Values.controller.template | indent 4 */}}
-{{ .Files.Get "haproxy.tmpl" | indent 4 }}
+{{- if .Values.controller.templateFile -}}
+{{ .Files.Get .Values.controller.templateFile | indent 4 }}
+{{- else }}
+{{ .Values.controller.template | indent 4 }}
+{{- end }}
 {{- end }}

--- a/haproxy-ingress/templates/controller-template.yaml
+++ b/haproxy-ingress/templates/controller-template.yaml
@@ -8,6 +8,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   haproxy.tmpl: |-
-{{ .Values.controller.template | indent 4 }}
-{{/* .Files.Get "haproxy.tmpl" | indent 4 */}}
+{{ (.Files.Glob "custom_template/haproxy.tmpl").AsConfig | indent 2 }}
 {{- end }}

--- a/haproxy-ingress/templates/controller-template.yaml
+++ b/haproxy-ingress/templates/controller-template.yaml
@@ -7,6 +7,5 @@ metadata:
   name: {{ include "haproxy-ingress.fullname" . }}-template
   namespace: {{ .Release.Namespace }}
 data:
-  haproxy.tmpl: |-
 {{ (.Files.Glob "custom_template/haproxy.tmpl").AsConfig | indent 2 }}
 {{- end }}

--- a/haproxy-ingress/templates/controller-template.yaml
+++ b/haproxy-ingress/templates/controller-template.yaml
@@ -8,9 +8,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   haproxy.tmpl: |
-{{- if .Values.controller.templateFile -}}
-{{ .Files.Get .Values.controller.templateFile | indent 4 }}
+{{- if .Values.controller.templateFile }}
+    {{- .Files.Get .Values.controller.templateFile | nindent 4 }}
 {{- else }}
-{{ .Values.controller.template | indent 4 }}
+    {{- .Values.controller.template | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/haproxy-ingress/templates/controller-template.yaml
+++ b/haproxy-ingress/templates/controller-template.yaml
@@ -7,5 +7,7 @@ metadata:
   name: {{ include "haproxy-ingress.fullname" . }}-template
   namespace: {{ .Release.Namespace }}
 data:
-{{ (.Files.Glob "custom_template/haproxy.tmpl").AsConfig | indent 2 }}
+  haproxy.tmpl: |
+{{/* .Values.controller.template | indent 4 */}}
+{{ .Files.Get "haproxy.tmpl" | indent 4 }}
 {{- end }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -53,7 +53,7 @@ controller:
   initContainers: []
 
   ## Custom haproxy template
-  ## if set to true loads custom_template/haproxy.tmpl into the custom template configmap
+  ## if set to true loads haproxy.tmpl into the custom template configmap
   template: false
 
   ## A manually deployed default backend service

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -52,8 +52,9 @@ controller:
   ## Additional containers that can initialize the pod.
   initContainers: []
 
-  # custom haproxy template
-  template: ""
+  ## Custom haproxy template
+  ## if set to true loads custom_template/haproxy.tmpl into the custom template configmap
+  template: false
 
   ## A manually deployed default backend service
   ## Ignored if defaultBackend.enabled = true

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -53,8 +53,9 @@ controller:
   initContainers: []
 
   ## Custom haproxy template
-  ## if set to true loads haproxy.tmpl into the custom template configmap
-  template: false
+  template: ""
+  ## Path to custom haproxy.tmpl to load into the configmap
+  templateFile: ""
 
   ## A manually deployed default backend service
   ## Ignored if defaultBackend.enabled = true


### PR DESCRIPTION
The current way of loading a custom haproxy template is broken
This change will load the custom template from `custom_template/haproxy.tmpl` if template is set to true in the values file