### PR TITLE
Add optional custom ConfigMap for the controller

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -146,8 +146,7 @@ Parameter | Description | Default
 `controller.priorityClassName` | Priority Class to be used | ``
 `controller.securityContext` | Security context settings for the haproxy-ingress-controller pod or container, see `controller.legacySecurityContext` | `{}`
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://haproxy-ingress.github.io/docs/configuration/keys/) | `{}`
-`controller.customMap` | set `true` to create custom ConfigMap to mount in the controller pod | `false`
-`controller.customMapData` | data to be added to custom ConfigMap | `""`
+`controller.customFiles` | Custom files to be mounted in the controller pod(s) | `{}`
 `controller.hostNetwork` | Optionally set to true when using CNI based kubernetes installations | `false`
 `controller.dnsPolicy` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' | `ClusterFirst`
 `controller.terminationGracePeriodSeconds` | How much to wait before terminating a pod (in seconds) | `60`

--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -146,6 +146,7 @@ Parameter | Description | Default
 `controller.priorityClassName` | Priority Class to be used | ``
 `controller.securityContext` | Security context settings for the haproxy-ingress-controller pod or container, see `controller.legacySecurityContext` | `{}`
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://haproxy-ingress.github.io/docs/configuration/keys/) | `{}`
+`controller.customMap` | set `true` to load custom files to the controller pod | `false`
 `controller.hostNetwork` | Optionally set to true when using CNI based kubernetes installations | `false`
 `controller.dnsPolicy` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' | `ClusterFirst`
 `controller.terminationGracePeriodSeconds` | How much to wait before terminating a pod (in seconds) | `60`

--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -146,7 +146,8 @@ Parameter | Description | Default
 `controller.priorityClassName` | Priority Class to be used | ``
 `controller.securityContext` | Security context settings for the haproxy-ingress-controller pod or container, see `controller.legacySecurityContext` | `{}`
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://haproxy-ingress.github.io/docs/configuration/keys/) | `{}`
-`controller.customMap` | set `true` to load custom files to the controller pod | `false`
+`controller.customMap` | set `true` to create custom ConfigMap to mount in the controller pod | `false`
+`controller.customMapData` | data to be added to custom ConfigMap | `""`
 `controller.hostNetwork` | Optionally set to true when using CNI based kubernetes installations | `false`
 `controller.dnsPolicy` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' | `ClusterFirst`
 `controller.terminationGracePeriodSeconds` | How much to wait before terminating a pod (in seconds) | `60`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -108,9 +108,9 @@ spec:
         - name: haproxy-template
           mountPath: /etc/templates/haproxy
 {{- end }}
-{{- if .Values.controller.customFiles }}
+{{- if and .Values.controller.customFiles (not .Values.controller.haproxy.enabled) }}
         - name: haproxy-custom-files
-          mountPath: /etc/haproxy-custom
+          mountPath: /etc/haproxy-custom-files
 {{- end }}
 {{- if .Values.controller.extraVolumeMounts }}
         {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
@@ -245,7 +245,7 @@ spec:
       configMap:
         name: {{ include "haproxy-ingress.fullname" . }}-template
 {{- end }}
-{{- if .Values.controller.customFiles }}
+{{- if and .Values.controller.customFiles (not .Values.controller.haproxy.enabled) }}
     - name: haproxy-custom-files
       configMap:
         name: {{ include "haproxy-ingress.fullname" . }}-custom-files

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -108,9 +108,9 @@ spec:
         - name: haproxy-template
           mountPath: /etc/templates/haproxy
 {{- end }}
-{{- if .Values.controller.customMap }}
-        - name: haproxy-custom-map
-          mountPath: /etc/custom_map
+{{- if .Values.controller.customFiles }}
+        - name: haproxy-custom-files
+          mountPath: /etc/haproxy-custom
 {{- end }}
 {{- if .Values.controller.extraVolumeMounts }}
         {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
@@ -245,10 +245,10 @@ spec:
       configMap:
         name: {{ include "haproxy-ingress.fullname" . }}-template
 {{- end }}
-{{- if .Values.controller.customMap }}
-    - name: haproxy-custom-map
+{{- if .Values.controller.customFiles }}
+    - name: haproxy-custom-files
       configMap:
-        name: {{ include "haproxy-ingress.fullname" . }}-custom-map
+        name: {{ include "haproxy-ingress.fullname" . }}-custom-files
 {{- end }}
 {{- if .Values.controller.extraVolumes }}
     {{- toYaml .Values.controller.extraVolumes | nindent 4 }}

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -108,6 +108,10 @@ spec:
         - name: haproxy-template
           mountPath: /etc/templates/haproxy
 {{- end }}
+{{- if .Values.controller.customMap }}
+        - name: haproxy-custom-map
+          mountPath: /etc/custom_map
+{{- end }}
 {{- if .Values.controller.extraVolumeMounts }}
         {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
 {{- end }}
@@ -240,6 +244,11 @@ spec:
     - name: haproxy-template
       configMap:
         name: {{ include "haproxy-ingress.fullname" . }}-template
+{{- end }}
+{{- if .Values.controller.customMap }}
+    - name: haproxy-custom-map
+      configMap:
+        name: {{ include "haproxy-ingress.fullname" . }}-custom-map
 {{- end }}
 {{- if .Values.controller.extraVolumes }}
     {{- toYaml .Values.controller.extraVolumes | nindent 4 }}

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -155,6 +155,10 @@ spec:
           name: lib
         - mountPath: /var/run/haproxy
           name: run
+{{- if .Values.controller.customFiles }}
+        - name: haproxy-custom-files
+          mountPath: /etc/haproxy-custom-files
+{{- end }}
 {{- if .Values.controller.extraVolumeMounts }}
         {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
 {{- end }}
@@ -245,7 +249,7 @@ spec:
       configMap:
         name: {{ include "haproxy-ingress.fullname" . }}-template
 {{- end }}
-{{- if and .Values.controller.customFiles (not .Values.controller.haproxy.enabled) }}
+{{- if .Values.controller.customFiles }}
     - name: haproxy-custom-files
       configMap:
         name: {{ include "haproxy-ingress.fullname" . }}-custom-files

--- a/haproxy-ingress/templates/controller-configmap-custom.yaml
+++ b/haproxy-ingress/templates/controller-configmap-custom.yaml
@@ -7,5 +7,5 @@ metadata:
   name: {{ include "haproxy-ingress.fullname" . }}-custom-map
   namespace: {{ .Release.Namespace }}
 data:
-{{ (.Files.Glob "custom_map/*").AsConfig | indent 4}}
+  {{- .Values.controller.customMapData | nindent 2 }}
 {{- end }}

--- a/haproxy-ingress/templates/controller-configmap-custom.yaml
+++ b/haproxy-ingress/templates/controller-configmap-custom.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.controller.customMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: "{{ include "haproxy-ingress.fullname" $ }}-custom-map"
+  namespace: {{ .Release.Namespace }}
+data:
+{{ (.Files.Glob "custom_map/*").AsConfig | indent 4}}
+{{- end }}

--- a/haproxy-ingress/templates/controller-configmap-custom.yaml
+++ b/haproxy-ingress/templates/controller-configmap-custom.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "haproxy-ingress.labels" . | nindent 4 }}
-  name: "{{ include "haproxy-ingress.fullname" $ }}-custom-map"
+  name: {{ include "haproxy-ingress.fullname" . }}-custom-map
   namespace: {{ .Release.Namespace }}
 data:
 {{ (.Files.Glob "custom_map/*").AsConfig | indent 4}}

--- a/haproxy-ingress/templates/controller-configmap-custom.yaml
+++ b/haproxy-ingress/templates/controller-configmap-custom.yaml
@@ -1,11 +1,13 @@
-{{- if .Values.controller.customMap }}
+{{- if .Values.controller.customFiles }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     {{- include "haproxy-ingress.labels" . | nindent 4 }}
-  name: {{ include "haproxy-ingress.fullname" . }}-custom-map
+  name: {{ include "haproxy-ingress.fullname" . }}-custom-files
   namespace: {{ .Release.Namespace }}
 data:
-  {{- .Values.controller.customMapData | nindent 2 }}
+{{- range $key, $value := .Values.controller.customFiles }}
+  {{ $key }}: {{ $value | toYaml | indent 2 | trim  }}
+{{- end }}
 {{- end }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -133,19 +133,14 @@ controller:
   # ConfigMap to configure haproxy ingress
   config: {}
 
-  # Custom ConfigMap to be mounted by the controller
-  # if set to true a ConfigMap and will be created and mounted in the controller pods in /etc/custom_map/
+  # Custom files to be mounted to the controller(s)
+  # if populated a ConfigMap will be created and mounted in the controller pods in /etc/haproxy-custom
   # An example usage is to add lua scripts or files containing matching patterns to be used in haproxy
-  # ConfigMap data needs to be loaded via customMapData
-  customMap: false
-  # an Example usage is to pass data via helm --set-file controller.customMapData=path/to/customData
-  # the file loaded this way must be in the following format
-  #cat customData
-  #hello.lua: |
-  #  core.Debug("Hello HAProxy!\n")
-  #hello_again.lua: |
-  #  core.Debug("Hello again HAProxy!\n")
-  customMapData: ""
+  customFiles: {}
+  #  hello.lua: |
+  #    core.Debug("Hello HAProxy!\n")
+  #  hello_again.lua: |
+  #    core.Debug("Hello again HAProxy!\n")
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -134,10 +134,18 @@ controller:
   config: {}
 
   # Custom ConfigMap to be mounted by the controller
-  # if set to true files in custom_map/* will be added to a ConfigMap and will be available in the controller pods
-  # in /etc/custom_map/
+  # if set to true a ConfigMap and will be created and mounted in the controller pods in /etc/custom_map/
   # An example usage is to add lua scripts or files containing matching patterns to be used in haproxy
+  # ConfigMap data needs to be loaded via customMapData
   customMap: false
+  # an Example usage is to pass data via helm --set-file controller.customMapData=path/to/customData
+  # the file loaded this way must be in the following format
+  #cat customData
+  #hello.lua: |
+  #  core.Debug("Hello HAProxy!\n")
+  #hello_again.lua: |
+  #  core.Debug("Hello again HAProxy!\n")
+  customMapData: ""
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -133,6 +133,12 @@ controller:
   # ConfigMap to configure haproxy ingress
   config: {}
 
+  # Custom ConfigMap to be mounted by the controller
+  # if set to true files in custom_map/* will be added to a ConfigMap and will be available in the controller pods
+  # in /etc/custom_map/
+  # An example usage is to add lua scripts or files containing matching patterns to be used in haproxy
+  customMap: false
+
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
   # is merged

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -134,7 +134,7 @@ controller:
   config: {}
 
   # Custom files to be mounted to the controller(s)
-  # if populated a ConfigMap will be created and mounted in the controller pods in /etc/haproxy-custom
+  # if populated a ConfigMap will be created and mounted in the controller pods in /etc/haproxy-custom-files
   # An example usage is to add lua scripts or files containing matching patterns to be used in haproxy
   customFiles: {}
   #  hello.lua: |


### PR DESCRIPTION
Hello!

this PR adds a simple way to load additional data to the controller pod from a configmap
The ConfigMap is populated globbing all files in the `custom_map` directory, i use this approach extensively but since i'm trying to stay as close to upstream as possible i'm submitting this change.

This is obviously completely optional and maintains 100% retrocompatibility
Let me know if you are interested in such addition

