### PR TITLE
Update PodDisruptionBudget version.

### DIFF
--- a/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/haproxy-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/haproxy-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.defaultBackend.enabled -}}
+{{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   labels:


### PR DESCRIPTION
PodDisruptionBudget is migrating from v1beta to v1. v1 is available
since v1.21 and v1beta will stop working in v1.25.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125

I am creating this PR in draft mode, because this change would bump the minimal kubernetes version from v1.8 to v.21 which might not be ok, so I would like to discuss some alternatives (for example to add some parameter to values.yaml to control which version should be used).