### PR TITLE
Allow specifying annotations for DaemonSets/Deployments

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -140,6 +140,7 @@ Parameter | Description | Default
 `controller.readinessProbe.periodSeconds` | The readiness probe period (in seconds) | `10`
 `controller.readinessProbe.successThreshold` | The readiness probe success threshold | `1`
 `controller.readinessProbe.timeoutSeconds` | The readiness probe timeout (in seconds) | `1`
+`controller.annotations` | Annotations to be added to DaemonSet/Deployment definitions | `{}`
 `controller.podAnnotations` | Annotations for the haproxy-ingress-controller pod | `{}`
 `controller.podLabels` | Labels for the haproxy-ingress-controller pod | `{}`
 `controller.podAffinity` | Add affinity to the controller pods to control scheduling | `{}`

--- a/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/haproxy-ingress/templates/controller-daemonset.yaml
@@ -2,6 +2,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  {{- with .Values.controller.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "haproxy-ingress.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.fullname" . }}

--- a/haproxy-ingress/templates/controller-deployment.yaml
+++ b/haproxy-ingress/templates/controller-deployment.yaml
@@ -2,6 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- with .Values.controller.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "haproxy-ingress.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.fullname" . }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -98,6 +98,10 @@ controller:
     successThreshold: 1
     timeoutSeconds: 1
 
+  ## Annotations to be added to DaemonSet/Deployment definitions
+  ##
+  annotations: {}
+
   ## Annotations to be added to controller pods
   ##
   podAnnotations: {}


### PR DESCRIPTION
# Description

This PR adds the option to specify annotations to the deployed workload.