### PR TITLE
Allow customFiles to be used without custom template

### DIFF
--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -237,7 +237,7 @@ spec:
   imagePullSecrets:
     {{- toYaml .Values.controller.imagePullSecrets | nindent 4 }}
 {{- end }}
-{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.templateFile .Values.controller.extraVolumes }}
+{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.templateFile .Values.controller.extraVolumes .Values.controller.customFiles }}
   volumes:
 {{- if .Values.controller.haproxy.enabled }}
     - name: etc

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -97,7 +97,7 @@ spec:
 {{- if .Values.controller.extraEnvs }}
         {{- toYaml .Values.controller.extraEnvs | nindent 8 }}
 {{- end }}
-{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.templateFile .Values.controller.extraVolumeMounts }}
+{{- if or .Values.controller.haproxy.enabled .Values.controller.template .Values.controller.templateFile .Values.controller.extraVolumeMounts .Values.controller.customFiles }}
       volumeMounts:
 {{- if .Values.controller.haproxy.enabled }}
         - mountPath: /etc/haproxy


### PR DESCRIPTION
Currently`controller.customFiles` cannot be used unless at least one of `Values.controller.haproxy.enabled .Values.controller.template .Values.controller.templateFile .Values.controller.extraVolumeMounts` is set, which i think is a bug since this option should be usable even without any of the other settings listed above, this PR will fix that.

