### PR TITLE
Add permissions for leases, needed by leaderelection

### DIFF
--- a/haproxy-ingress/templates/role.yaml
+++ b/haproxy-ingress/templates/role.yaml
@@ -8,6 +8,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - ""
     resources:
       - pods


### PR DESCRIPTION
An upcoming change to haproxy-ingress will start using leases instead of configmaps for leader election: https://github.com/jcmoraisjr/haproxy-ingress/commit/c7d8ae39fe4d6e4850a3ef548f1059ee7a8b06c4#diff-f0300b4e07ed00177998e7e533050c4dd3264d2327be0c87640565d42943f566R58

If you ran the master image with the latest version of the helm chart without this PR, leader election would fail due to these missing RBAC rules. Adding these rules now means the transition will be smooth for when the next version is released.