### PR TITLE
Helm chart improvements

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -99,7 +99,8 @@ Parameter | Description | Default
 `serviceAccount.create` | If true, create serviceAccount | `true`
 `serviceAccount.name` | ServiceAccount to be used | ``
 `controller.name` | name of the controller component | `controller`
-`controller.image.repository` | controller container image repository | `quay.io/jcmoraisjr/haproxy-ingress`
+`controller.image.registry` | controller container image registry | `quay.io`
+`controller.image.repository` | controller container image repository | `jcmoraisjr/haproxy-ingress`
 `controller.image.tag` | controller container image tag | `v0.14.0`
 `controller.image.pullPolicy` | controller container image pullPolicy | `IfNotPresent`
 `controller.imagePullSecrets` | controller image pull secrets | `[]`
@@ -118,6 +119,7 @@ Parameter | Description | Default
 `controller.ingressClassResource.controllerClass` | customizes the [controller name](https://haproxy-ingress.github.io/docs/configuration/command-line/#ingress-class) | `''`
 `controller.ingressClassResource.parameters` |  | `{}`
 `controller.haproxy.enabled` | set `true` to configure haproxy as a sidecar instead of use the embedded version | `false`
+`controller.haproxy.image.registry` | haproxy container image registry, when enabled | `docker.io`
 `controller.haproxy.image.repository` | haproxy container image repository, when enabled | `haproxy`
 `controller.haproxy.image.tag` | haproxy container image tag | `2.4.20-alpine`
 `controller.haproxy.image.pullPolicy` | haproxy container image pullPolicy | `IfNotPresent`
@@ -157,6 +159,8 @@ Parameter | Description | Default
 `controller.kind` | Type of deployment, DaemonSet or Deployment | `Deployment`
 `controller.tcp` | TCP [service ConfigMap](https://haproxy-ingress.github.io/docs/configuration/command-line/#tcp-services-configmap): `<port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]` | `{}`
 `controller.enableStaticPorts` | Set to `false` to only rely on ports from `controller.tcp` | `true`
+`controller.containerPorts.http` | HTTP container port in the controller | `80`
+`controller.containerPorts.https` |  HTTPS container port in the controller | `443`
 `controller.daemonset.useHostPort` | Set to true to use host ports 80 and 443 | `false`
 `controller.daemonset.hostIP` | Change the IP the host ports will bind to | `nil`
 `controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty sets the hostPort for http | `"80"`
@@ -208,7 +212,8 @@ Parameter | Description | Default
 `controller.metrics.embedded` | defines if embedded haproxy's exporter should be used | `true`
 `controller.metrics.port` | port number the exporter is listening to | `9101`
 `controller.metrics.controllerPort` | port number the controller is exporting metrics on | `10254`
-`controller.metrics.image.repository` | prometheus-exporter image repository when embedded is `false` | `quay.io/prometheus/haproxy-exporter`
+`controller.metrics.image.registry` | prometheus-exporter image registry when embedded is `false` | `quay.io`
+`controller.metrics.image.repository` | prometheus-exporter image repository when embedded is `false` | `prometheus/haproxy-exporter`
 `controller.metrics.image.tag` | prometheus-exporter image tag | `v0.11.0`
 `controller.metrics.image.pullPolicy` | prometheus-exporter image pullPolicy | `IfNotPresent`
 `controller.metrics.extraArgs` | Extra arguments to the prometheus-exporter |  `{}`
@@ -233,6 +238,7 @@ Parameter | Description | Default
 `controller.serviceMonitor.ctrlMetrics.metricRelabelings` | Metric relabel configs to apply to samples before ingestion for controller metric | `[]`
 `controller.serviceMonitor.ctrlMetrics.relabelings` | Relabel configs to apply to samples before ingestion for controller metric | `[]`
 `controller.logs.enabled` | enable an access-logs sidecar container that collects access logs from haproxy and outputs to stdout | `false`
+`controller.logs.image.registry` | access-logs container image registry | `docker.io`
 `controller.logs.image.repository` | access-logs container image repository | `whereisaaron/kube-syslog-sidecar`
 `controller.logs.image.tag` | access-logs image tag | `latest`
 `controller.logs.image.pullPolicy` | access-logs image pullPolicy | `IfNotPresent`
@@ -243,9 +249,11 @@ Parameter | Description | Default
 `controller.logs.resources` | access-logs container resource requests & limits |  `{}`
 `defaultBackend.enabled` | whether to use the default backend component | `false`
 `defaultBackend.name` | name of the default backend component | `default-backend`
-`defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend-amd64`
+`defaultBackend.image.registry` | default backend container image registry | `k8s.gcr.io`
+`defaultBackend.image.repository` | default backend container image repository | `defaultbackend-amd64`
 `defaultBackend.image.tag` | default backend container image repository tag | `1.5`
 `defaultBackend.image.pullPolicy` | default backend container image pullPolicy | `IfNotPresent`
+`defaultBackend.imagePullSecrets` | default backend pull secrets | `[]`
 `defaultBackend.tolerations` | to control scheduling to servers with taints | `[]`
 `defaultBackend.affinity` | to control scheduling | `{}`
 `defaultBackend.nodeSelector` | to control scheduling | `{}`
@@ -266,3 +274,4 @@ Parameter | Description | Default
 `defaultBackend.service.servicePort` | the port number exposed by the metrics service | `1936`
 `defaultBackend.service.type` | type of controller service to create | `ClusterIP`
 `defaultBackend.securityContext` | custom POD security context for the default backend container | `{runAsNonRoot: true, runAsUser: 65000, runAsGroup: 65000, fsGroup: 65000}`
+`defaultBackend.priorityClassName` | Priority Class to be used | ``

--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -99,8 +99,7 @@ Parameter | Description | Default
 `serviceAccount.create` | If true, create serviceAccount | `true`
 `serviceAccount.name` | ServiceAccount to be used | ``
 `controller.name` | name of the controller component | `controller`
-`controller.image.registry` | controller container image registry | `quay.io`
-`controller.image.repository` | controller container image repository | `jcmoraisjr/haproxy-ingress`
+`controller.image.repository` | controller container image repository | `quay.io/jcmoraisjr/haproxy-ingress`
 `controller.image.tag` | controller container image tag | `v0.14.0`
 `controller.image.pullPolicy` | controller container image pullPolicy | `IfNotPresent`
 `controller.imagePullSecrets` | controller image pull secrets | `[]`
@@ -119,7 +118,6 @@ Parameter | Description | Default
 `controller.ingressClassResource.controllerClass` | customizes the [controller name](https://haproxy-ingress.github.io/docs/configuration/command-line/#ingress-class) | `''`
 `controller.ingressClassResource.parameters` |  | `{}`
 `controller.haproxy.enabled` | set `true` to configure haproxy as a sidecar instead of use the embedded version | `false`
-`controller.haproxy.image.registry` | haproxy container image registry, when enabled | `docker.io`
 `controller.haproxy.image.repository` | haproxy container image repository, when enabled | `haproxy`
 `controller.haproxy.image.tag` | haproxy container image tag | `2.4.20-alpine`
 `controller.haproxy.image.pullPolicy` | haproxy container image pullPolicy | `IfNotPresent`
@@ -212,8 +210,7 @@ Parameter | Description | Default
 `controller.metrics.embedded` | defines if embedded haproxy's exporter should be used | `true`
 `controller.metrics.port` | port number the exporter is listening to | `9101`
 `controller.metrics.controllerPort` | port number the controller is exporting metrics on | `10254`
-`controller.metrics.image.registry` | prometheus-exporter image registry when embedded is `false` | `quay.io`
-`controller.metrics.image.repository` | prometheus-exporter image repository when embedded is `false` | `prometheus/haproxy-exporter`
+`controller.metrics.image.repository` | prometheus-exporter image repository when embedded is `false` | `quay.io/prometheus/haproxy-exporter`
 `controller.metrics.image.tag` | prometheus-exporter image tag | `v0.11.0`
 `controller.metrics.image.pullPolicy` | prometheus-exporter image pullPolicy | `IfNotPresent`
 `controller.metrics.extraArgs` | Extra arguments to the prometheus-exporter |  `{}`
@@ -238,7 +235,6 @@ Parameter | Description | Default
 `controller.serviceMonitor.ctrlMetrics.metricRelabelings` | Metric relabel configs to apply to samples before ingestion for controller metric | `[]`
 `controller.serviceMonitor.ctrlMetrics.relabelings` | Relabel configs to apply to samples before ingestion for controller metric | `[]`
 `controller.logs.enabled` | enable an access-logs sidecar container that collects access logs from haproxy and outputs to stdout | `false`
-`controller.logs.image.registry` | access-logs container image registry | `docker.io`
 `controller.logs.image.repository` | access-logs container image repository | `whereisaaron/kube-syslog-sidecar`
 `controller.logs.image.tag` | access-logs image tag | `latest`
 `controller.logs.image.pullPolicy` | access-logs image pullPolicy | `IfNotPresent`
@@ -249,8 +245,7 @@ Parameter | Description | Default
 `controller.logs.resources` | access-logs container resource requests & limits |  `{}`
 `defaultBackend.enabled` | whether to use the default backend component | `false`
 `defaultBackend.name` | name of the default backend component | `default-backend`
-`defaultBackend.image.registry` | default backend container image registry | `k8s.gcr.io`
-`defaultBackend.image.repository` | default backend container image repository | `defaultbackend-amd64`
+`defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend-amd64`
 `defaultBackend.image.tag` | default backend container image repository tag | `1.5`
 `defaultBackend.image.pullPolicy` | default backend container image pullPolicy | `IfNotPresent`
 `defaultBackend.imagePullSecrets` | default backend pull secrets | `[]`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -22,7 +22,7 @@ spec:
   initContainers:
 {{- if .Values.controller.haproxy.enabled }}
     - name: haproxy-ingress-init
-      image:  "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+      image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
       args:
         - --init
@@ -43,7 +43,7 @@ spec:
 {{- end }}
   containers:
     - name: haproxy-ingress
-      image:  "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+      image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
       args:
         - --configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.fullname" . }}
@@ -131,7 +131,7 @@ spec:
 {{- end }}
 {{- if .Values.controller.haproxy.enabled }}
     - name: haproxy
-      image: "{{ .Values.controller.haproxy.image.registry }}/{{ .Values.controller.haproxy.image.repository }}:{{ .Values.controller.haproxy.image.tag }}"
+      image: "{{ .Values.controller.haproxy.image.repository }}:{{ .Values.controller.haproxy.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.haproxy.image.pullPolicy }}"
       args:
         - -W
@@ -172,7 +172,7 @@ spec:
 {{- end }}
 {{- if .Values.controller.logs.enabled }}
     - name: access-logs
-      image:  "{{ .Values.controller.logs.image.registry }}/{{ .Values.controller.logs.image.repository }}:{{ .Values.controller.logs.image.tag }}"
+      image: "{{ .Values.controller.logs.image.repository }}:{{ .Values.controller.logs.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.logs.image.pullPolicy }}"
       ports:
         - name: udp
@@ -203,7 +203,7 @@ spec:
 {{- end }}
 {{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled (not .Values.controller.metrics.embedded) }}
     - name: prometheus-exporter
-      image:  "{{ .Values.controller.metrics.image.registry }}/{{ .Values.controller.metrics.image.repository }}:{{ .Values.controller.metrics.image.tag }}"
+      image: "{{ .Values.controller.metrics.image.repository }}:{{ .Values.controller.metrics.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.metrics.image.pullPolicy }}"
       args:
         - '--haproxy.scrape-uri=http://localhost:{{ .Values.controller.stats.port }}/haproxy?stats;csv'

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -22,7 +22,7 @@ spec:
   initContainers:
 {{- if .Values.controller.haproxy.enabled }}
     - name: haproxy-ingress-init
-      image:  "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+      image:  "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
       args:
         - --init
@@ -43,7 +43,7 @@ spec:
 {{- end }}
   containers:
     - name: haproxy-ingress
-      image:  "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+      image:  "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
       args:
         - --configmap={{ .Release.Namespace }}/{{ include "haproxy-ingress.fullname" . }}
@@ -131,7 +131,7 @@ spec:
 {{- end }}
 {{- if .Values.controller.haproxy.enabled }}
     - name: haproxy
-      image: "{{ .Values.controller.haproxy.image.repository }}:{{ .Values.controller.haproxy.image.tag }}"
+      image: "{{ .Values.controller.haproxy.image.registry }}/{{ .Values.controller.haproxy.image.repository }}:{{ .Values.controller.haproxy.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.haproxy.image.pullPolicy }}"
       args:
         - -W
@@ -172,7 +172,7 @@ spec:
 {{- end }}
 {{- if .Values.controller.logs.enabled }}
     - name: access-logs
-      image:  "{{ .Values.controller.logs.image.repository }}:{{ .Values.controller.logs.image.tag }}"
+      image:  "{{ .Values.controller.logs.image.registry }}/{{ .Values.controller.logs.image.repository }}:{{ .Values.controller.logs.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.logs.image.pullPolicy }}"
       ports:
         - name: udp
@@ -203,7 +203,7 @@ spec:
 {{- end }}
 {{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled (not .Values.controller.metrics.embedded) }}
     - name: prometheus-exporter
-      image:  "{{ .Values.controller.metrics.image.repository }}:{{ .Values.controller.metrics.image.tag }}"
+      image:  "{{ .Values.controller.metrics.image.registry }}/{{ .Values.controller.metrics.image.repository }}:{{ .Values.controller.metrics.image.tag }}"
       imagePullPolicy: "{{ .Values.controller.metrics.image.pullPolicy }}"
       args:
         - '--haproxy.scrape-uri=http://localhost:{{ .Values.controller.stats.port }}/haproxy?stats;csv'
@@ -220,6 +220,10 @@ spec:
           containerPort: {{ .Values.controller.metrics.port }}
           protocol: TCP
       livenessProbe:
+        httpGet:
+          path: /
+          port: metrics
+      readinessProbe:
         httpGet:
           path: /
           port: metrics
@@ -295,7 +299,7 @@ spec:
 {{- define "haproxy-ingress.controller.ports" }}
 {{- if .Values.controller.enableStaticPorts }}
 - name: http
-  containerPort: 80
+  containerPort: {{ .Values.controller.containerPorts.http }}
   {{- if eq .Values.controller.kind "DaemonSet" }}
     {{- if .Values.controller.daemonset.hostIP }}
   hostIP: {{ .Values.controller.daemonset.hostIP }}
@@ -305,7 +309,7 @@ spec:
     {{- end }}
   {{- end }}
 - name: https
-  containerPort: 443
+  containerPort: {{ .Values.controller.containerPorts.https }}
   {{- if eq .Values.controller.kind "DaemonSet" }}
     {{- if .Values.controller.daemonset.hostIP }}
   hostIP: {{ .Values.controller.daemonset.hostIP }}

--- a/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.defaultBackend.name }}
-          image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
+          image: "{{ .Values.defaultBackend.image.registry }}/{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
           imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
           livenessProbe:
             failureThreshold: 3
@@ -82,5 +82,12 @@ spec:
         runAsUser: 65000
         runAsGroup: 65000
         fsGroup: 65000
+    {{- end }}
+    {{- if .Values.defaultBackend.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.defaultBackend.imagePullSecrets | nindent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.priorityClassName }}
+      priorityClassName: {{ .Values.defaultBackend.priorityClassName | quote }}
     {{- end }}
 {{- end }}

--- a/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.defaultBackend.name }}
-          image: "{{ .Values.defaultBackend.image.registry }}/{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
+          image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
           imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
           livenessProbe:
             failureThreshold: 3

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -19,8 +19,7 @@ fullnameOverride: ""
 
 controller:
   image:
-    registry: quay.io
-    repository: jcmoraisjr/haproxy-ingress
+    repository: quay.io/jcmoraisjr/haproxy-ingress
     tag: v0.14.0
     pullPolicy: IfNotPresent
 
@@ -329,7 +328,6 @@ controller:
     enabled: false
 
     image:
-      registry: docker.io
       repository: haproxy
       tag: "2.4.20-alpine"
       pullPolicy: IfNotPresent
@@ -391,8 +389,7 @@ controller:
     # (scrapes the stats port and exports metrics to prometheus)
     # Only used if embedded == false
     image:
-      registry: quay.io
-      repository: prometheus/haproxy-exporter
+      repository: quay.io/prometheus/haproxy-exporter
       tag: "v0.11.0"
       pullPolicy: IfNotPresent
 
@@ -519,8 +516,7 @@ defaultBackend:
 
   name: default-backend
   image:
-    registry: k8s.gcr.io
-    repository: defaultbackend-amd64
+    repository: k8s.gcr.io/defaultbackend-amd64
     tag: "1.5"
     pullPolicy: IfNotPresent
 

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -482,7 +482,6 @@ controller:
     # https://github.com/whereisaaron/kube-syslog-sidecar
     # (listens on UDP port 514 and outputs to stdout)
     image:
-      registry: docker.io
       repository: whereisaaron/kube-syslog-sidecar
       tag: latest
       pullPolicy: IfNotPresent

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -19,7 +19,8 @@ fullnameOverride: ""
 
 controller:
   image:
-    repository: quay.io/jcmoraisjr/haproxy-ingress
+    registry: quay.io
+    repository: jcmoraisjr/haproxy-ingress
     tag: v0.14.0
     pullPolicy: IfNotPresent
 
@@ -188,6 +189,11 @@ controller:
   tcp: {}
   #  8080: "default/example-tcp-svc:9000"
 
+  # default values for http and https containerPorts
+  containerPorts:
+    http: 80
+    https: 443
+
   # optionally disable static ports, including the default 80 and 443
   enableStaticPorts: true
 
@@ -323,6 +329,7 @@ controller:
     enabled: false
 
     image:
+      registry: docker.io
       repository: haproxy
       tag: "2.4.20-alpine"
       pullPolicy: IfNotPresent
@@ -384,7 +391,8 @@ controller:
     # (scrapes the stats port and exports metrics to prometheus)
     # Only used if embedded == false
     image:
-      repository: quay.io/prometheus/haproxy-exporter
+      registry: quay.io
+      repository: prometheus/haproxy-exporter
       tag: "v0.11.0"
       pullPolicy: IfNotPresent
 
@@ -477,6 +485,7 @@ controller:
     # https://github.com/whereisaaron/kube-syslog-sidecar
     # (listens on UDP port 514 and outputs to stdout)
     image:
+      registry: docker.io
       repository: whereisaaron/kube-syslog-sidecar
       tag: latest
       pullPolicy: IfNotPresent
@@ -510,9 +519,13 @@ defaultBackend:
 
   name: default-backend
   image:
-    repository: k8s.gcr.io/defaultbackend-amd64
+    registry: k8s.gcr.io
+    repository: defaultbackend-amd64
     tag: "1.5"
     pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+  # - name: secret-name
 
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -576,3 +589,7 @@ defaultBackend:
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext: {}
+
+  ## Priority Class for the default backend container
+  ##
+  priorityClassName: ""


### PR DESCRIPTION
Hey! I would like to propose minor changes:

- ~extracted registry value to a separate variable (opens up the possibility of using image registry mirrors)~
- dehardcoded controller container ports
- added missing `imagePullSecrets` and `priorityClassName` for default backend
- added missing `readinessProbe` for prometheus-exporter