### PR TITLE
Fix securityContext conditional in default backend

### DIFF
--- a/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-{{- if .Values.controller.securityContext }}
+{{- if .Values.defaultBackend.securityContext }}
           securityContext:
             {{- toYaml .Values.defaultBackend.securityContext | nindent 12 }}
 {{- end }}


### PR DESCRIPTION
The conditional for default backend was checking controller security context instead of default backend security context.