### PR TITLE
improve log sidecar for multiple architectures

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -238,9 +238,9 @@ Parameter | Description | Default
 `controller.serviceMonitor.ctrlMetrics.metricRelabelings` | Metric relabel configs to apply to samples before ingestion for controller metric | `[]`
 `controller.serviceMonitor.ctrlMetrics.relabelings` | Relabel configs to apply to samples before ingestion for controller metric | `[]`
 `controller.logs.enabled` | enable an access-logs sidecar container that collects access logs from haproxy and outputs to stdout | `false`
-`controller.logs.image.registry` | access-logs container image registry | `docker.io`
-`controller.logs.image.repository` | access-logs container image repository | `whereisaaron/kube-syslog-sidecar`
-`controller.logs.image.tag` | access-logs image tag | `latest`
+`controller.logs.image.registry` | access-logs container image registry | `ghcr.io`
+`controller.logs.image.repository` | access-logs container image repository | `crisu1710/kube-syslog-sidecar`
+`controller.logs.image.tag` | access-logs image tag | `main`
 `controller.logs.image.pullPolicy` | access-logs image pullPolicy | `IfNotPresent`
 `controller.logs.extraVolumeMounts` | extra volume mounts for the access-logs container | `[]`
 `controller.logs.port` | port used by sidecar logs container | `514`

--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -240,7 +240,7 @@ Parameter | Description | Default
 `controller.logs.enabled` | enable an access-logs sidecar container that collects access logs from haproxy and outputs to stdout | `false`
 `controller.logs.image.registry` | access-logs container image registry | `ghcr.io`
 `controller.logs.image.repository` | access-logs container image repository | `crisu1710/kube-syslog-sidecar`
-`controller.logs.image.tag` | access-logs image tag | `0.1.0`
+`controller.logs.image.tag` | access-logs image tag | `0.2.0`
 `controller.logs.image.pullPolicy` | access-logs image pullPolicy | `IfNotPresent`
 `controller.logs.extraVolumeMounts` | extra volume mounts for the access-logs container | `[]`
 `controller.logs.port` | port used by sidecar logs container | `514`

--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -240,7 +240,7 @@ Parameter | Description | Default
 `controller.logs.enabled` | enable an access-logs sidecar container that collects access logs from haproxy and outputs to stdout | `false`
 `controller.logs.image.registry` | access-logs container image registry | `ghcr.io`
 `controller.logs.image.repository` | access-logs container image repository | `crisu1710/kube-syslog-sidecar`
-`controller.logs.image.tag` | access-logs image tag | `main`
+`controller.logs.image.tag` | access-logs image tag | `0.1.0`
 `controller.logs.image.pullPolicy` | access-logs image pullPolicy | `IfNotPresent`
 `controller.logs.extraVolumeMounts` | extra volume mounts for the access-logs container | `[]`
 `controller.logs.port` | port used by sidecar logs container | `514`

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -482,12 +482,13 @@ controller:
     enabled: false
 
     # syslog for haproxy
-    # https://github.com/whereisaaron/kube-syslog-sidecar
+    # https://github.com/crisu1710/kube-syslog-sidecar
     # (listens on UDP port 514 and outputs to stdout)
+    # registry needs to be in quotes
     image:
-      registry: docker.io
-      repository: whereisaaron/kube-syslog-sidecar
-      tag: latest
+      registry: "ghcr.io"
+      repository: crisu1710/kube-syslog-sidecar
+      tag: main
       pullPolicy: IfNotPresent
 
     ## Additional volume mounts

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -488,7 +488,7 @@ controller:
     image:
       registry: "ghcr.io"
       repository: crisu1710/kube-syslog-sidecar
-      tag: main
+      tag: "0.1.0"
       pullPolicy: IfNotPresent
 
     ## Additional volume mounts

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -488,7 +488,7 @@ controller:
     image:
       registry: "ghcr.io"
       repository: crisu1710/kube-syslog-sidecar
-      tag: "0.1.0"
+      tag: "0.2.0"
       pullPolicy: IfNotPresent
 
     ## Additional volume mounts


### PR DESCRIPTION
Hi,

While setting up haproxy-ingress on my Raspberry Pi K3s cluster, I run into an issue with the syslog sidecar.

It was not starting up, the log shows:  `syslog-ng: exec format error`.

I figured out that the used image is not supporting arm64, so I created a fork of it, which is now automatically building images for multiple architectures (linux/arm64, linux/amd64, linux/arm/v7).

With this PR, the sidecar will now pull the needed architecture of the images and the error is gone.
It also uses the latest version of alpine as base image now.

Thanks for the nice project works well in my cluster!

Best regards
Robin