### PR TITLE
chore: update autoscale apiVersion

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -9,7 +9,7 @@ This chart bootstraps an HAProxy Ingress deployment on a [Kubernetes](http://kub
 ## Prerequisites
 
 * Helm 3 installed, see installation instructions [here](https://helm.sh/docs/intro/install/)
-* Kubernetes 1.8+ with Beta APIs enabled
+* Kubernetes 1.23+ with Beta APIs enabled
 
 ## Installing the Chart
 

--- a/haproxy-ingress/templates/controller-hpa.yaml
+++ b/haproxy-ingress/templates/controller-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.controller.kind "Deployment") .Values.controller.autoscaling.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:


### PR DESCRIPTION
Kubernetes 1.26 removed it

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126