### PR TITLE
Defaults securityContext to allow privileged ports

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -146,7 +146,7 @@ Parameter | Description | Default
 `controller.podAnnotations` | Annotations for the haproxy-ingress-controller pod | `{}`
 `controller.podLabels` | Labels for the haproxy-ingress-controller pod | `{}`
 `controller.podAffinity` | Add affinity to the controller pods to control scheduling | `{}`
-`controller.podSecurityContext` | Security context settings for the haproxy-ingress-controller pod | `{}`
+`controller.podSecurityContext` | Security context settings for the haproxy-ingress-controller pod | `{"sysctls":"net.ipv4.ip_unprivileged_port_start=1"}`
 `controller.priorityClassName` | Priority Class to be used | ``
 `controller.securityContext` | Security context settings for the haproxy-ingress-controller pod or container, see `controller.legacySecurityContext` | `{}`
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://haproxy-ingress.github.io/docs/configuration/keys/) | `{}`

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -123,8 +123,13 @@ controller:
 
   ## Security context settings to be added to the controller pods
   ##
-  podSecurityContext: {}
-  #  sysctls:
+  ## Preserve the value below if haproxy is configured to
+  ## listen to a privileged port - less than 1024.
+  ##
+  podSecurityContext:
+    sysctls:
+    - name: "net.ipv4.ip_unprivileged_port_start"
+      value: "1"
   #  - name: net.ipv4.ip_local_port_range
   #    value: "1024 65535"
 


### PR DESCRIPTION
Since haproxy starts to run as nonroot (uid 99), it fails to start on container envs that doesn't change unprivileged starting port to a lower value, usually 0. This update makes the helm chart configure that by default for the sysadmin, making HAProxy Ingress easier to configure.