### PR TITLE
Revert default securityContext config

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -146,7 +146,7 @@ Parameter | Description | Default
 `controller.podAnnotations` | Annotations for the haproxy-ingress-controller pod | `{}`
 `controller.podLabels` | Labels for the haproxy-ingress-controller pod | `{}`
 `controller.podAffinity` | Add affinity to the controller pods to control scheduling | `{}`
-`controller.podSecurityContext` | Security context settings for the haproxy-ingress-controller pod | `{"sysctls":"net.ipv4.ip_unprivileged_port_start=1"}`
+`controller.podSecurityContext` | Security context settings for the haproxy-ingress-controller pod | `{}`
 `controller.priorityClassName` | Priority Class to be used | ``
 `controller.securityContext` | Security context settings for the haproxy-ingress-controller pod or container, see `controller.legacySecurityContext` | `{}`
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://haproxy-ingress.github.io/docs/configuration/keys/) | `{}`

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -123,13 +123,8 @@ controller:
 
   ## Security context settings to be added to the controller pods
   ##
-  ## Preserve the value below if haproxy is configured to
-  ## listen to a privileged port - less than 1024.
-  ##
-  podSecurityContext:
-    sysctls:
-    - name: "net.ipv4.ip_unprivileged_port_start"
-      value: "1"
+  podSecurityContext: {}
+  #  sysctls:
   #  - name: net.ipv4.ip_local_port_range
   #    value: "1024 65535"
 


### PR DESCRIPTION
HAProxy 2.4 and newer starts as UID `99`, and there is nothing we can safely do by default to fix that when user configures external haproxy. sysctls config is being reverted because it will not work with `hostNetwork`, and can fail as well depending on cluster security policies.

Added some configuration options and respective drawbacks in the external haproxy example page.