### PR TITLE
Add lifecycle hooks to external HAProxy container

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -125,6 +125,7 @@ Parameter | Description | Default
 `controller.haproxy.image.pullPolicy` | haproxy container image pullPolicy | `IfNotPresent`
 `controller.haproxy.extraArgs` | extra command line arguments for haproxy | `{}`
 `controller.haproxy.resources` | haproxy container resource requests & limits | `{}`
+`controller.haproxy.lifecycle` | Lifecycle hooks for haproxy container | `{}`
 `controller.haproxy.securityContext` | Security context settings for the haproxy container | `{}`
 `controller.healthzPort` | The haproxy health check (monitoring) port | `10253`
 `controller.legacySecurityContext` | Defines if `controller.securityContext` should be applied to the controller's pod (legacy: true) or container (legacy: false)  | `true`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -165,6 +165,10 @@ spec:
 {{- if .Values.controller.extraVolumeMounts }}
         {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
 {{- end }}
+{{- if .Values.controller.haproxy.lifecycle }}
+      lifecycle:
+        {{- toYaml .Values.controller.haproxy.lifecycle | nindent 8 }}
+{{- end }}
 {{- if .Values.controller.haproxy.securityContext }}
       securityContext:
         {{- toYaml .Values.controller.haproxy.securityContext | nindent 8 }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -347,6 +347,12 @@ controller:
     #    cpu: 500m
     #    memory: 768Mi
 
+    # Configure container lifecycle. When scaling replicas down this can be
+    # used to prevent controller container from terminating quickly and drop in-flight requests.
+    # For example, when the controller runs behind Network Load Balancer this can be used
+    # to configure preStop hook to sleep along with deregistration_delay.
+    lifecycle: {}
+
     ## Container Security Context for the haproxy container
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     ##


### PR DESCRIPTION
This allows the use of container lifecycle hooks on the `haproxy` container when the external/sidecar HAProxy mode is enabled.