### PR TITLE
Add support to disable automountServiceAccountToken

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -98,6 +98,8 @@ Parameter | Description | Default
 `rbac.security.enable` | If true, and rbac.create is true, create & use PSP resources on Kubernetes clusters up to v1.25 | `false`
 `serviceAccount.create` | If true, create serviceAccount | `true`
 `serviceAccount.name` | ServiceAccount to be used | ``
+`serviceAccount.automountServiceAccountToken` | Automount API credentials for the ServiceAccount | `true` |
+`controller.automountServiceAccountToken` | Automount API credentials to the controller's pod | `true` |
 `controller.name` | name of the controller component | `controller`
 `controller.image.registry` | controller container image registry | `quay.io`
 `controller.image.repository` | controller container image repository | `jcmoraisjr/haproxy-ingress`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -18,6 +18,7 @@ spec:
     {{- toYaml .Values.controller.podAffinity | nindent 4 }}
 {{- end }}
   serviceAccountName: {{ include "haproxy-ingress.serviceAccountName" . }}
+  automountServiceAccountToken: {{ .Values.controller.automountServiceAccountToken }}
 {{- if or .Values.controller.haproxy.enabled .Values.controller.initContainers }}
   initContainers:
 {{- if .Values.controller.haproxy.enabled }}

--- a/haproxy-ingress/templates/serviceaccount.yaml
+++ b/haproxy-ingress/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   labels:
     {{- include "haproxy-ingress.labels" . | nindent 4 }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -15,6 +15,8 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  # Automount API credentials for the ServiceAccount.
+  automountServiceAccountToken: true
 
 nameOverride: ""
 fullnameOverride: ""
@@ -148,6 +150,9 @@ controller:
   #    core.Debug("Hello HAProxy!\n")
   #  hello_again.lua: |
   #    core.Debug("Hello again HAProxy!\n")
+
+  # Automount API credentials to the controller's pod
+  automountServiceAccountToken: true
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920


### PR DESCRIPTION
Currently our Microsoft Azure Defender for Containers setup flags the haproxy-ingress pod with a high severity security finding.

Cert-manager has a nice write-up https://cert-manager.io/docs/installation/best-practice/#restrict-auto-mount-of-service-account-tokens

I added `serviceAccount.automountServiceAccountToken` and defaulted to `true` because:
- aligns with Kubernetes behavior: https://github.com/kubernetes/kubernetes/blob/ad150771936bdd2594b545c6932ae46d8fec4e62/plugin/pkg/admission/serviceaccount/admission.go#L264
- ingress-nginx also defaults to true: https://github.com/kubernetes/ingress-nginx/blob/8a578c9f4a268cba2d75fc40d4e5f4bb3e17a714/charts/ingress-nginx/values.yaml#L768

I added `controller.automountServiceAccountToken` because `serviceAccount.create` can be set to false.

I contemplated adding a `hasKey` check, but decided against it since the default `true` is backwards compatible with any current install of this chart and the check would then only unnecessarily complicate the code.

Example usage:
```yaml
serviceAccount:
  automountServiceAccountToken: false
  
controller:
  automountServiceAccountToken: false
  extraVolumes:
  - name: serviceaccount-token
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
        expirationSeconds: 3607
        path: token
      - configMap:
        name: kube-root-ca.crt
        items:
        - key: ca.crt
          path: ca.crt
      - downwardAPI:
        items:
        - path: namespace
          fieldRef:
          apiVersion: v1
          fieldPath: metadata.namespace
  extraVolumeMounts:
  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
    name: serviceaccount-token
    readOnly: true 
```

@jcmoraisjr Let me know if you'd like any changes. And can this be released in v0.14?  😄 