### PR TITLE
Allow adding annotations on the ServiceAccount

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -99,6 +99,7 @@ Parameter | Description | Default
 `serviceAccount.create` | If true, create serviceAccount | `true`
 `serviceAccount.name` | ServiceAccount to be used | ``
 `serviceAccount.automountServiceAccountToken` | Automount API credentials for the ServiceAccount | `true` |
+`serviceAccount.annotations` | A list of annotations to add to the ServiceAccount | ``
 `controller.automountServiceAccountToken` | Automount API credentials to the controller's pod | `true` |
 `controller.name` | name of the controller component | `controller`
 `controller.image.registry` | controller container image registry | `quay.io`

--- a/haproxy-ingress/templates/serviceaccount.yaml
+++ b/haproxy-ingress/templates/serviceaccount.yaml
@@ -9,4 +9,8 @@ metadata:
     {{- include "haproxy-ingress.labels" . | nindent 4 }}
   name: {{ include "haproxy-ingress.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/haproxy-ingress/templates/serviceaccount.yaml
+++ b/haproxy-ingress/templates/serviceaccount.yaml
@@ -5,12 +5,12 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 metadata:
-  labels:
-    {{- include "haproxy-ingress.labels" . | nindent 4 }}
-  name: {{ include "haproxy-ingress.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
+  labels:
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -10,6 +10,9 @@ rbac:
 
 # Create ServiceAccount
 serviceAccount:
+  # Annotations to be added to the ServiceAccount
+  annotations: {}
+  # - eks.amazonaws.com/role-arn: "arn:aws:iam::111111111111:role/some-role-name"
   # Specifies whether a ServiceAccount should be created
   create: true
   # The name of the ServiceAccount to use.


### PR DESCRIPTION
Allow specifying annotations that will be added to the ServiceAccount. 

This fixes [jcmoraisjr/haproxy-ingress/issues/1056](https://github.com/jcmoraisjr/haproxy-ingress/issues/1056).