### PR TITLE
Set securityContext for haproxy init container

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -152,6 +152,7 @@ Parameter | Description | Default
 `controller.podSecurityContext` | Security context settings for the haproxy-ingress-controller pod | `{}`
 `controller.priorityClassName` | Priority Class to be used | ``
 `controller.securityContext` | Security context settings for the haproxy-ingress-controller pod or container, see `controller.legacySecurityContext` | `{}`
+`controller.securityContextInitContainer` | Security context settings for the init container | `{}`
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://haproxy-ingress.github.io/docs/configuration/keys/) | `{}`
 `controller.customFiles` | Custom files to be mounted in the controller pod(s) | `{}`
 `controller.hostNetwork` | Optionally set to true when using CNI based kubernetes installations | `false`

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -39,9 +39,9 @@ spec:
       volumeMounts:
         - mountPath: /etc/haproxy
           name: etc
-{{- if .Values.controller.haproxy.initContainer.securityContext }}
+{{- if .Values.controller.securityContextInitContainer }}
       securityContext:
-        {{- toYaml .Values.controller.haproxy.initContainer.securityContext | nindent 8 }}
+        {{- toYaml .Values.controller.securityContextInitContainer | nindent 8 }}
 {{- end }}
 {{- end }}
 {{- if .Values.controller.initContainers }}

--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -39,6 +39,10 @@ spec:
       volumeMounts:
         - mountPath: /etc/haproxy
           name: etc
+{{- if .Values.controller.haproxy.initContainer.securityContext }}
+      securityContext:
+        {{- toYaml .Values.controller.haproxy.initContainer.securityContext | nindent 8 }}
+{{- end }}
 {{- end }}
 {{- if .Values.controller.initContainers }}
     {{- toYaml .Values.controller.initContainers | nindent 4 }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -135,6 +135,11 @@ controller:
   securityContext: {}
   #  readOnlyRootFilesystem: true
 
+  ## Security context for the init container, when init container is configured
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContextInitContainer: {}
+
   # Defines if controller.securityContext should be applied in the
   # controller's pod (if legacy: true) or the container (if legacy: false)
   legacySecurityContext: true
@@ -364,12 +369,6 @@ controller:
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     ##
     securityContext: {}
-
-    initContainer:
-      ## Container Security Context for the haproxy init container
-      ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-      ##
-      securityContext: {}
 
   stats:
     enabled: false

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -365,6 +365,12 @@ controller:
     ##
     securityContext: {}
 
+    initContainer:
+      ## Container Security Context for the haproxy init container
+      ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+      ##
+      securityContext: {}
+
   stats:
     enabled: false
     port: 1936


### PR DESCRIPTION
The init container is currently the only container where no `securityContext` could be set. That is causing issues in environments with strict security constraints. This commit introduces a new key `controller.haproxy.initContainer.securityContext` similar to existing `securityContext` keys.