### PR TITLE
Allow custom labels to be added to the controllers DaemonSet/Deployment

### DIFF
--- a/haproxy-ingress/README.md
+++ b/haproxy-ingress/README.md
@@ -148,6 +148,7 @@ Parameter | Description | Default
 `controller.readinessProbe.timeoutSeconds` | The readiness probe timeout (in seconds) | `1`
 `controller.annotations` | Annotations to be added to DaemonSet/Deployment definitions | `{}`
 `controller.podAnnotations` | Annotations for the haproxy-ingress-controller pod | `{}`
+`controller.labels` | Labels to be added to DaemonSet/Deployment definitions | `{}`
 `controller.podLabels` | Labels for the haproxy-ingress-controller pod | `{}`
 `controller.podAffinity` | Add affinity to the controller pods to control scheduling | `{}`
 `controller.podSecurityContext` | Security context settings for the haproxy-ingress-controller pod | `{}`

--- a/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/haproxy-ingress/templates/controller-daemonset.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/haproxy-ingress/templates/controller-deployment.yaml
+++ b/haproxy-ingress/templates/controller-deployment.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -110,6 +110,10 @@ controller:
   ##
   annotations: {}
 
+  ## Labels to be added to DaemonSet/Deployment definitions
+  ##
+  labels: {}
+
   ## Annotations to be added to controller pods
   ##
   podAnnotations: {}


### PR DESCRIPTION
This change to the helm chart allows labels to be added to the controllers DaemonSet/Deployment