### PR TITLE
PodDisruptionBudget - Add feature to control PDB via maxUnavailable as well

### DIFF
--- a/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.controller.minAvailable (gt .Values.controller.replicaCount .Values.controller.minAvailable)) (gt (.Values.controller.maxUnavailable | int) 0) }}
+{{- if or (and .Values.controller.minAvailable (gt .Values.controller.replicaCount .Values.controller.minAvailable)) (ge (.Values.controller.maxUnavailable | int) 0) }}
 {{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}

--- a/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.minAvailable (gt .Values.controller.replicaCount .Values.controller.minAvailable) }}
+{{- if or (and .Values.controller.minAvailable (gt .Values.controller.replicaCount .Values.controller.minAvailable)) (gt (.Values.controller.maxUnavailable | int) 0) }}
 {{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}
@@ -14,5 +14,9 @@ spec:
   selector:
     matchLabels:
       {{- include "haproxy-ingress.selectorLabels" . | nindent 6 }}
+  {{- if .Values.controller.maxUnavailable }}
+  maxUnavailable: {{ .Values.controller.maxUnavailable }}
+  {{- else }}
   minAvailable: {{ .Values.controller.minAvailable }}
+  {{- end }}
 {{- end }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -248,7 +248,10 @@ controller:
 
   # A PodDisruptionBudget is created only if minAvailable is
   # greater than 0 (zero) and lesser than the replicaCount
+  # or if maxUnavailable is set and bigger than 0.
+  # If both are set, maxUnavailable takes precedence
   minAvailable: 1
+  #maxUnavailable: 1
 
   resources: {}
   #  limits:

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -248,7 +248,7 @@ controller:
 
   # A PodDisruptionBudget is created only if minAvailable is
   # greater than 0 (zero) and lesser than the replicaCount
-  # or if maxUnavailable is set and bigger than 0.
+  # or if maxUnavailable is set.
   # If both are set, maxUnavailable takes precedence
   minAvailable: 1
   #maxUnavailable: 1


### PR DESCRIPTION
PDB is the main guarantor of how an application behaves when predictable disruptions occur (nodes scaling up, down, new deployments, etc.).

While PDB is already supported, there're some cases where even if the current PDB, some "instability" can be caused.
Consider the following scenario:

---

The cluster is receiving quite a bit of traffic, so HPA is doing it's job and scales `haproxy-ingress` to `20` replicas. The relevant CRDs have the following values:

```
PDB:
- Min Available: 5
HPA:
- Min replicas: 5
- Max replicas: 30
- Desired replicas: 20
Deployment:
- Replicas: 20
```

Given the above situation, if there's some event in the cluster (maybe nodes scaling down), of the existing `20` replicas, `15` can be put in `Terminating` state to shuffle the workloads around. At that point, it would be 3/4 of the replicas going into `Terminating` which would put a lot of pressure in the remaining replicas.

---

The case above is a bit extreme, but is shows that the option `MinAvailable` in `PDB` not always pairs very well with `HorizontalPodAutoscaler` and why I think that `maxUnavailable` is better suited for these cases.

If a PDB is configured with `maxUnavailable`, that will be completely independent of the current amount of replicas. In extreme, an operator could decide to set `maxUnavailable` to `1` to make sure, in no circumstance, more than 1 replica is `Terminated` - either it being a new deployment of `haproxy-ingress`, or a node scale down event, or other.

Let me know what you think :)