### PR TITLE
feat: add VerticalPodAutoscaler resource for controller

### DIFF
--- a/haproxy-ingress/templates/controller-vpa.yaml
+++ b/haproxy-ingress/templates/controller-vpa.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.controller.vpa.enabled -}}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+  {{- fail "controller.vpa.enabled requires the VerticalPodAutoscaler CRD (autoscaling.k8s.io/v1). Install the VPA CRDs before enabling this feature: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#installation" }}
+{{- end }}
+{{- if and .Values.controller.autoscaling.enabled (ne (.Values.controller.vpa.updatePolicy.updateMode | default "Recreate") "Off") }}
+  {{- fail "controller.vpa with updateMode != 'Off' must not be used together with controller.autoscaling (HPA). Set controller.vpa.updatePolicy.updateMode to 'Off' to use VPA for recommendations only, or disable the HPA." }}
+{{- end }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  {{- with .Values.controller.vpa.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "haproxy-ingress.labels" . | nindent 4 }}
+  name: {{ include "haproxy-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: {{ .Values.controller.kind }}
+    name: {{ include "haproxy-ingress.fullname" . }}
+  {{- with .Values.controller.vpa.updatePolicy }}
+  updatePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.controller.vpa.resourcePolicy }}
+  resourcePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.controller.vpa.recommenders }}
+  recommenders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.controller.vpa.startupBoost }}
+  startupBoost:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -283,8 +283,58 @@ controller:
     #  targetMemoryUtilizationPercentage: 50
     customMetrics: []
     # Enable using external HPA by removing number of replicas
-    # from the Controller deployment, but not deplying the HPA object   
+    # from the Controller deployment, but not deplying the HPA object
     useExternalHPA: false
+
+  ## VerticalPodAutoscaler configuration
+  ## Ref: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/
+  ##
+  ## XXX Requires the VPA CRD and controller to be installed in the cluster.
+  ## See: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#installation
+  ##
+  vpa:
+    enabled: false
+    annotations: {}
+    ## updatePolicy controls how the autoscaler applies resource recommendation changes
+    ## updateMode defaults to "Off" (recommendation-only, no pod mutations).
+    updatePolicy:
+      updateMode: "Off"
+    #   updateMode: "Recreate"  # "Off", "Initial", "Recreate", "InPlaceOrRecreate" ("Auto" is deprecated)
+    #   minReplicas: 2
+    #   evictionRequirements:
+    #     - resources: ["cpu", "memory"]
+    #       changeRequirement: TargetHigherThanRequests
+    ## resourcePolicy controls per-container resource recommendation constraints
+    resourcePolicy: {}
+    #   containerPolicies:
+    #     - containerName: haproxy-ingress
+    #       minAllowed:
+    #         cpu: 100m
+    #         memory: 128Mi
+    #       maxAllowed:
+    #         cpu: "2"
+    #         memory: 2Gi
+    #       controlledResources: ["cpu", "memory"]
+    #       controlledValues: RequestsAndLimits  # or RequestsOnly
+    #     - containerName: haproxy
+    #       minAllowed:
+    #         cpu: 100m
+    #         memory: 128Mi
+    #       maxAllowed:
+    #         cpu: "2"
+    #         memory: 2Gi
+    #       controlledResources: ["cpu", "memory"]
+    #       controlledValues: RequestsAndLimits
+    ## recommenders allows specifying a custom VPA recommender
+    recommenders: []
+    #   - name: custom-recommender
+    ## startupBoost specifies a CPU startup boost policy for the pod
+    startupBoost: {}
+    #   cpu:
+    #     type: Factor
+    #     factor: 3
+    #     durationSeconds: 120
 
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -342,11 +392,11 @@ controller:
     httpPorts:
       - port: 80
         targetPort: http
-      # nodePort:
+        # nodePort:
     httpsPorts:
       - port: 443
         targetPort: https
-      # nodePort:
+        # nodePort:
 
     ## Add extra ports to the service
     ## Useful when adding the 'tcp-service-port' configuration key


### PR DESCRIPTION
A fail guard prevents enabling VPA in a mutating mode (Recreate, Initial, InPlaceOrRecreate) together with HPA, avoiding the well-known conflict where both fight over CPU/memory. VPA with updateMode Off (recommendation-only) remains allowed alongside HPA. The guard defaults to Recreate per upstream API defaults.

Aligns with the upstream VPA v1 API including the deprecated Auto mode note and the newer InPlaceOrRecreate mode.