### PR TITLE
create pdb only if max unavailable is defined

### DIFF
--- a/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.controller.minAvailable (gt .Values.controller.replicaCount .Values.controller.minAvailable)) (ge (.Values.controller.maxUnavailable | int) 0) }}
+{{- if or (and .Values.controller.minAvailable (gt .Values.controller.replicaCount .Values.controller.minAvailable)) (hasKey .Values.controller "maxUnavailable") }}
 {{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}
@@ -14,7 +14,7 @@ spec:
   selector:
     matchLabels:
       {{- include "haproxy-ingress.selectorLabels" . | nindent 6 }}
-  {{- if .Values.controller.maxUnavailable }}
+  {{- if hasKey .Values.controller "maxUnavailable" }}
   maxUnavailable: {{ .Values.controller.maxUnavailable }}
   {{- else }}
   minAvailable: {{ .Values.controller.minAvailable }}


### PR DESCRIPTION
PDB should be created either if minAvailable is greater than the replica count, or maxUnavailable is defined. PDB however is always being generated because a non declared maxUnavailable renders to `0`. This update checks for the presence of maxUnavailable field instead of checking its value, so `0` is also a valid configuration.