### PR TITLE
manually mount sa only in controller pod

### DIFF
--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -19,7 +19,7 @@ spec:
 {{- end }}
   serviceAccountName: {{ include "haproxy-ingress.serviceAccountName" . }}
 {{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.Version }}
-  automountServiceAccountToken: {{ .Values.controller.automountServiceAccountToken }}
+  automountServiceAccountToken: false
 {{- end }}
 {{- if or .Values.controller.haproxy.enabled .Values.controller.initContainers }}
   initContainers:
@@ -122,6 +122,11 @@ spec:
 {{- if and .Values.controller.customFiles (not .Values.controller.haproxy.enabled) }}
         - name: haproxy-custom-files
           mountPath: /etc/haproxy-custom-files
+{{- end }}
+{{- if and (semverCompare ">= 1.22-0" .Capabilities.KubeVersion.Version) .Values.controller.automountServiceAccountToken }}
+        - name: kube-api-access
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
 {{- end }}
 {{- if .Values.controller.extraVolumeMounts }}
         {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
@@ -258,6 +263,25 @@ spec:
   volumes:
     - name: scratch
       emptyDir: {}
+{{- if and (semverCompare ">= 1.22-0" .Capabilities.KubeVersion.Version) .Values.controller.automountServiceAccountToken }}
+    - name: kube-api-access
+      projected:
+        defaultMode: 0644
+        sources:
+        - serviceAccountToken:
+            expirationSeconds: 3600
+            path: token
+        - configMap:
+            name: kube-root-ca.crt
+            items:
+            - key: ca.crt
+              path: ca.crt
+        - downwardAPI:
+            items:
+            - path: namespace
+              fieldRef:
+                fieldPath: metadata.namespace
+{{- end }}
 {{- if or .Values.controller.template .Values.controller.templateFile }}
     - name: haproxy-template
       configMap:

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -170,7 +170,10 @@ controller:
   #  hello_again.lua: |
   #    core.Debug("Hello again HAProxy!\n")
 
-  # Automount API credentials to the controller's pod
+  # Automount API credentials to the controller's pod.
+  # Note: this option does not use automountServiceAccountToken in the Pod spec, which is always configured as false.
+  # When true: ServiceAccount token is manually mounted only in the controller container, sidecars are excluded.
+  # When false: ServiceAccount token is not mounted to any container, out-of-cluster authentication should be used.
   automountServiceAccountToken: true
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),


### PR DESCRIPTION
Changing from the pod level service account auto mount to a manually mount only in the controller pod. This removes the service account token from other containers, improving security.