### PR TITLE
Access logs lifecycle

### DIFF
--- a/haproxy-ingress/templates/_podtemplate.yaml
+++ b/haproxy-ingress/templates/_podtemplate.yaml
@@ -219,6 +219,10 @@ spec:
       securityContext:
         {{- toYaml .Values.controller.logs.securityContext | nindent 8 }}
 {{- end }}
+{{- if .Values.controller.logs.lifecycle }}
+      lifecycle:
+        {{- toYaml .Values.controller.logs.lifecycle | nindent 8 }}
+{{- end }}
 {{- end }}
 {{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled (not .Values.controller.metrics.embedded) }}
     - name: prometheus-exporter

--- a/haproxy-ingress/values.yaml
+++ b/haproxy-ingress/values.yaml
@@ -612,7 +612,9 @@ controller:
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     ##
     securityContext: {}
-
+    
+    # If lifecycle is added to the haproxy container, it can be useful to also configure it here to ensure the syslog container is not killed before haproxy when the pod is terminating, allowing it to flush the logs properly.
+    lifecycle: {}
     # port used by syslog container
     port: 514
 


### PR DESCRIPTION
Add `controller.logs.lifecycle` to the access-logs sidecar container template, matching the pattern already used by the controller and haproxy containers.

This allows configuring a `preStop` hook on the syslog sidecar — useful when the `haproxy` container also has a `lifecycle` rule to, for example, need a drain period before termination. Without this, the syslog container can exit before HAProxy finishes serving in-flight requests, causing those requests to go unlogged.
